### PR TITLE
Sort imports

### DIFF
--- a/features/conference/components/Conference.js
+++ b/features/conference/components/Conference.js
@@ -1,14 +1,14 @@
 import React, { Component } from 'react';
 import { Text } from 'react-native';
+import { connect } from 'react-redux';
 
 import BigVideo from '../../media/components/BigVideo';
-import ConferenceContainer from './native/ConferenceContainer';
-import ParticipantsContainer from './native/ParticipantsContainer';
 import LocalVideoThumbnail from '../../media/components/LocalVideoThumbnail';
 import RemoteVideoThumbnail from '../../media/components/RemoteVideoThumbnail';
 import Toolbar from '../../toolbar/components/Toolbar';
 
-import { connect } from 'react-redux';
+import ConferenceContainer from './native/ConferenceContainer';
+import ParticipantsContainer from './native/ParticipantsContainer';
 
 class Conference extends Component {
     render() {

--- a/features/media/components/BigVideo.js
+++ b/features/media/components/BigVideo.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
-import Video from './native/Video';
-import BigVideoContainer from './native/BigVideoContainer';
-
 import { connect } from 'react-redux';
+
+import BigVideoContainer from './native/BigVideoContainer';
+import Video from './native/Video';
 
 class BigVideo extends Component {
     render() {

--- a/features/media/components/LocalVideoThumbnail.js
+++ b/features/media/components/LocalVideoThumbnail.js
@@ -1,8 +1,7 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import VideoThumbnail from './VideoThumbnail';
-
-import { connect } from 'react-redux';
 
 class LocalVideoThumbnail extends Component {
     render() {

--- a/features/media/components/RemoteVideoThumbnail.js
+++ b/features/media/components/RemoteVideoThumbnail.js
@@ -1,8 +1,7 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import VideoThumbnail from './VideoThumbnail';
-
-import { connect } from 'react-redux';
 
 class RemoteVideoThumbnail extends Component {
     render() {

--- a/features/media/components/VideoThumbnail.js
+++ b/features/media/components/VideoThumbnail.js
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 
 // TODO: import depending on environment
-import VideoThumbnailContainer from './native/VideoThumbnailContainer';
 import Audio from './native/Audio';
 import Video from './native/Video';
-// import VideoThumbnailContainer from './browser/VideoThumbnailContainer';
+import VideoThumbnailContainer from './native/VideoThumbnailContainer';
 // import Audio from './browser/Audio';
 // import Video from './browser/Video';
+// import VideoThumbnailContainer from './browser/VideoThumbnailContainer';
 
 class VideoThumbnail extends Component {
     render() {

--- a/features/media/components/native/Audio.js
+++ b/features/media/components/native/Audio.js
@@ -1,5 +1,5 @@
-import { RTCView } from 'react-native-webrtc';
 import React, { Component } from 'react';
+import { RTCView } from 'react-native-webrtc';
 
 class Audio extends Component {
     render() {

--- a/features/media/components/native/Video.js
+++ b/features/media/components/native/Video.js
@@ -1,5 +1,5 @@
-import { RTCView } from 'react-native-webrtc';
 import React, { Component } from 'react';
+import { RTCView } from 'react-native-webrtc';
 
 import styles from './styles/VideoStyle';
 

--- a/features/toolbar/components/Toolbar.js
+++ b/features/toolbar/components/Toolbar.js
@@ -1,10 +1,9 @@
 import React, { Component } from 'react';
-
-import ToolbarContainer from './native/ToolbarContainer';
-
 import { connect } from 'react-redux';
 
-const Actions = require('../../actions');
+import * as Actions from '../../actions';
+
+import ToolbarContainer from './native/ToolbarContainer';
 
 /**
  * The conference call toolbar.

--- a/features/toolbar/components/native/ToolbarContainer.js
+++ b/features/toolbar/components/native/ToolbarContainer.js
@@ -4,6 +4,7 @@ import {  View,
           TouchableHighlight } from 'react-native';
 
 import colorPalette from '../../../base/styles/components/native/styles/ColorPalette';
+
 import styles from './styles/ToolbarStyle';
 
 import Icon from 'react-native-vector-icons/FontAwesome';

--- a/features/toolbar/components/native/styles/ToolbarStyle.js
+++ b/features/toolbar/components/native/styles/ToolbarStyle.js
@@ -1,4 +1,5 @@
 import { StyleSheet } from 'react-native';
+
 import ColorPalette from '../../../../base/styles/components/native/styles/ColorPalette';
 
 /**

--- a/features/welcome/components/WelcomePage.js
+++ b/features/welcome/components/WelcomePage.js
@@ -1,13 +1,11 @@
 import React, { Component } from 'react';
-
-import Conference from '../../conference/components/Conference';
-import WelcomePageContainer from './native/WelcomePageContainer';
-
 import { connect } from 'react-redux';
 
+import * as Actions from '../../actions';
+import Conference from '../../conference/components/Conference';
 import Config from '../../../config';
 
-import * as Actions from '../../actions';
+import WelcomePageContainer from './native/WelcomePageContainer';
 
 
 /**


### PR DESCRIPTION
We have the beginning of a project structure organized by features
where inside a feature there are imports of (1) third-party modules such
as react, react-native, react-redux, (2) modules exported by other features
and (3) modules internal to the feature. In order to make the imports
easier to read, group them by their origin and then sort them in
alphabetical order within the group.
