### PR TITLE
Organize base/styles like the other features

### DIFF
--- a/features/base/styles/components/_.android.js
+++ b/features/base/styles/components/_.android.js
@@ -1,0 +1,1 @@
+export * from './native';

--- a/features/base/styles/components/_.ios.js
+++ b/features/base/styles/components/_.ios.js
@@ -1,0 +1,1 @@
+export * from './native';

--- a/features/base/styles/components/index.js
+++ b/features/base/styles/components/index.js
@@ -1,0 +1,1 @@
+export * from './_';

--- a/features/base/styles/components/native/index.js
+++ b/features/base/styles/components/native/index.js
@@ -1,0 +1,1 @@
+export * from './styles/ColorPalette';

--- a/features/base/styles/components/native/styles/ColorPalette.js
+++ b/features/base/styles/components/native/styles/ColorPalette.js
@@ -1,11 +1,11 @@
 /**
  * The application color palette.
  */
-var ColorPalette = {
+const ColorPalette = {
     buttonUnderlay: '#495258',
     jitsiBlue: '#00ccff',
     jitsiRed: '#ff0000',
     jitsiToggled: this.buttonUnderlay
 }
 
-export default ColorPalette;
+export ColorPalette;

--- a/features/base/styles/index.js
+++ b/features/base/styles/index.js
@@ -1,0 +1,1 @@
+export * from './components';

--- a/features/toolbar/components/native/ToolbarContainer.js
+++ b/features/toolbar/components/native/ToolbarContainer.js
@@ -3,7 +3,7 @@ import {  View,
           Text,
           TouchableHighlight } from 'react-native';
 
-import colorPalette from '../../../base/styles/components/native/styles/ColorPalette';
+import { ColorPalette } from '../../../base/styles';
 
 import styles from './styles/Styles';
 
@@ -14,7 +14,7 @@ import Icon from 'react-native-vector-icons/FontAwesome';
  */
 export class ToolbarContainer extends Component {
     render() {
-        var underlayColor = colorPalette.buttonUnderlay;
+        var underlayColor = ColorPalette.buttonUnderlay;
         var micButtonStyle;
         var micButtonIcon;
         if (this.props.audioMuted) {
@@ -36,7 +36,7 @@ export class ToolbarContainer extends Component {
               </TouchableHighlight>
               <TouchableHighlight
                   style = {[ styles.toolbarButton,
-                                { backgroundColor: colorPalette.jitsiRed }]}
+                                { backgroundColor: ColorPalette.jitsiRed }]}
                   onPress = { () => this.props.onHangup() }
                   underlayColor = { underlayColor }>
                   <Icon style = { styles.icon } name = "phone"/>

--- a/features/toolbar/components/native/styles/Styles.js
+++ b/features/toolbar/components/native/styles/Styles.js
@@ -1,6 +1,6 @@
 import { StyleSheet } from 'react-native';
 
-import ColorPalette from '../../../../base/styles/components/native/styles/ColorPalette';
+import { ColorPalette } from '../../../../base/styles';
 
 /**
  * The toolbar related styles.

--- a/features/welcome/components/native/styles/Styles.js
+++ b/features/welcome/components/native/styles/Styles.js
@@ -1,6 +1,6 @@
 import { StyleSheet } from 'react-native';
 
-import ColorPalette from '../../../../base/styles/components/native/styles/ColorPalette';
+import { ColorPalette } from '../../../../base/styles';
 
 /**
  * The welcome page style.


### PR DESCRIPTION
Now that the other features have a way to switch between Native and Web
and use an import-export logic based on features rather than on files,
make base/styles consistent with the other features.
