### PR TITLE
Couple of webpack improvements for "web" build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "clean": "rm -rf dist",
     "build:web": "mkdir -p dist/; cp -r static/* dist/; webpack",
     "start:ios": "npm run clean; react-native run-ios",
-    "start:web": "webpack-dev-server --colors --port 5000 --https --history-api-fallback --open"
+    "start:web": "webpack-dev-server --inline --hot --colors --port 5000 --https --history-api-fallback --open"
   },
   "dependencies": {
     "getconfig": "^3.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = {
     },
     cache: true,
     debug: true,
-    devtool: false,
+    devtool: 'source-map',
     entry: {
         app: __dirname + '/index.web.js'
     },


### PR DESCRIPTION
Run webpack-dev-server in "inline" mode with hot module replacement, support source-maps for builds
