### PR TITLE
Fix Navigator on Android

### DIFF
--- a/index.native.js
+++ b/index.native.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { AppRegistry, NavigatorIOS } from 'react-native';
+import { AppRegistry, Navigator } from 'react-native';
 import { Provider } from 'react-redux';
 import { applyMiddleware, createStore } from 'redux';
 import Thunk from 'redux-thunk';
@@ -13,8 +13,8 @@ import { Conference } from './features/conference';
 import { init, styles, WelcomePage } from './features/welcome';
 
 /**
- * This router middleware is used to abstract navigation
- * inside the app for both native and web.
+ * This router middleware is used to abstract navigation inside the app for both
+ * native and web.
  */
 const router = store => next => action => {
     if (action.type === APP_NAVIGATE) {
@@ -36,23 +36,54 @@ const router = store => next => action => {
     return next(action);
 };
 
-
 const reducer = ReducerRegistry.combineReducers();
 const store = createStore(reducer, applyMiddleware(Thunk, router));
 
 class Root extends Component {
+    /**
+     * Initializes a new Root instance.
+     *
+     * @param {object} props - the read-only properties with which the new
+     * instance is to be initialized
+     */
+    constructor(props) {
+        super(props);
+
+        // Bind event handlers so they are only bound once for every instance.
+        this._navigatorRenderScene = this._navigatorRenderScene.bind(this);
+    }
+
     render() {
         return (
             <Provider store={store}>
-                <NavigatorIOS
-                    style={styles.navContainer}
+                <Navigator
                     initialRoute={{
                         title: 'Jitsi Meet',
                         component: WelcomePage
                     }}
+                    renderScene={this._navigatorRenderScene}
+                    style={styles.navContainer}
                 />
           </Provider>
         );
+    }
+
+    /**
+     * Renders the scene identified by a specific route in a specific Navigator.
+     *
+     * @param {object} route - the route which identifies the scene to be
+     * rendered in the specified navigator. In the fashion of NavigatorIOS, the
+     * specified route is expected to define a value for its component property
+     * which is the type of React component to be rendered.
+     * @param {Navigator} navigator - the Navigator in which the scene
+     * identified by the specified route is to be rendered
+     * @private
+     */
+    _navigatorRenderScene(route, navigator) {
+        // We started with NavigatorIOS and then switched to Navigator in order
+        // to support Android as well. In order to reduce the number of
+        // modifications, accept the same format of route definition.
+        return React.createElement(route.component, { navigator });
     }
 }
 


### PR DESCRIPTION
We started with NavigatorIOS but now we want to support Android in
addition to iOS. Switch from NavigatorIOS to Navigator in order to take
advantage of the cross-platform and React Native-maintained
characteristics of the latter component.
