### PR TITLE
Fix RTCView idiosyncrasies

### DIFF
--- a/features/base/media/components/native/Audio.js
+++ b/features/base/media/components/native/Audio.js
@@ -1,13 +1,16 @@
 import React, { Component } from 'react';
 import { RTCView } from 'react-native-webrtc';
 
+/**
+ * The React Native component which is similar to Web's audio element and wraps
+ * around react-native-webrtc's RTCView.
+ */
 export class Audio extends Component {
     render() {
-        let streamUrl = this.props.stream ? this.props.stream.toURL() : '';
-
-        return (
-            <RTCView streamURL={streamUrl}/>
-        );
+        // TODO react-native-webrtc's RTCView doesn't do anything with the audio
+        // MediaStream specified to it so it's easier at the time of this
+        // writing to not render anything.
+        return null;
     }
 }
 

--- a/features/base/media/components/native/Video.js
+++ b/features/base/media/components/native/Video.js
@@ -4,7 +4,8 @@ import { RTCView } from 'react-native-webrtc';
 import styles from './styles/Styles';
 
 /**
- * The video native container wrapping around the RTCView.
+ * The React Native component which is similar to Web's video element and wraps
+ * around react-native-webrtc's RTCView.
  */
 export class Video extends Component {
     componentDidMount() {
@@ -16,11 +17,21 @@ export class Video extends Component {
     }
 
     render() {
-        let streamUrl = this.props.stream ? this.props.stream.toURL() : '';
+        let stream = this.props.stream;
 
-        return (
-            <RTCView style = { styles.video } streamURL={streamUrl}/>
-        );
+        if (stream) {
+            let streamURL = stream.toURL();
+
+            return (
+                <RTCView style={ styles.video } streamURL={ streamURL }/>
+            );
+        }
+
+        // RTCView has peculiarities which may or may not be platform specific.
+        // For example, it doesn't accept an empty streamURL. If the execution
+        // reached here, it means that we explicitly chose to not initialize an
+        // RTCView as a way of dealing with its idiosyncrasies.
+        return null;
     }
 }
 


### PR DESCRIPTION
1. RTCView doesn't do anything with audio so it's much easier at the
   time of this writing to not render the Audio component. Otherwise, we
   get into source code duplication without reason.
2. The implementations of RTCView differ between Android and iOS with
   respect to the value of streamURL: Android doesn't treat an empty string
   the same way as null/undefined like iOS. At the time of this writing it
   is much easier to deal with that difference in the Video component.
