### PR TITLE
Require jsdoc comments on methods, functions and classes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,39 @@ module.exports = {
         "max-len": [
             "error",
             80
+        ],
+        "require-jsdoc": [
+            "error",
+            {
+                "require": {
+                    "FunctionDeclaration": true,
+                    "MethodDefinition": true,
+                    "ClassDeclaration": true
+                }
+            }
+        ],
+        "valid-jsdoc": [
+            "error",
+            {
+                "prefer": {
+                    "arg": "param",
+                    "argument": "param",
+                    "return": "returns"
+                },
+                "preferType": {
+                    "Boolean": "boolean",
+                    "Number": "number",
+                    "String": "string",
+                    "object": "Object",
+                    "array": "Array",
+                    "function": "Function"
+                },
+                "requireReturn": true,
+                "requireReturnType": true,
+                "matchDescription": ".+",
+                "requireParamDescription": false,
+                "requireReturnDescription": false
+            }
         ]
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,8 @@ module.exports = {
         "sourceType": "module"
     },
     "plugins": [
-        "react"
+        "react",
+        "jsdoc"
     ],
     "rules": {
         "indent": [
@@ -50,6 +51,9 @@ module.exports = {
                 }
             }
         ],
+        // Currently we are using both valid-jsdoc and 'jsdoc' plugin,
+        // but in future we might stick to a single one in future as soon as
+        // one of them has all features.
         "valid-jsdoc": [
             "error",
             {
@@ -69,9 +73,30 @@ module.exports = {
                 "requireReturn": true,
                 "requireReturnType": true,
                 "matchDescription": ".+",
-                "requireParamDescription": false,
+                "requireParamDescription": true,
                 "requireReturnDescription": false
             }
-        ]
+        ],
+        // These rules are additional to valid-jsdoc.
+        "jsdoc/check-tag-names": [
+            "error"
+        ],
+        "jsdoc/newline-after-description": [
+            "error"
+        ],
+        "jsdoc/require-description-complete-sentence": [
+            "error"
+        ],
+        "jsdoc/require-hyphen-before-param-description": [
+            "error"
+        ],
+        // Those rules are covered by valid-jsdoc, so disable them.
+        "jsdoc/check-types": 0,
+        "jsdoc/check-param-names": 0,
+        "jsdoc/require-param": 0,
+        "jsdoc/require-param-description": 0,
+        "jsdoc/require-param-type": 0,
+        "jsdoc/require-returns-description": 0,
+        "jsdoc/require-returns-type": 0
     }
 };

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ ios/JitsiMeetApp.xcodeproj/xcuserdata
 ios/JitsiMeetApp.xcodeproj/project.xcworkspace
 node_modules
 dist
+npm-debug.log
 

--- a/config.js
+++ b/config.js
@@ -1,11 +1,10 @@
 module.exports = {
-  connection: {
-    bosh: 'https://meet.jit.si/http-bind',
-    hosts: {
-        domain: 'meet.jit.si',
-        focus: 'focus.meet.jit.si',
-        muc: 'conference.meet.jit.si'
+    connection: {
+        bosh: 'https://meet.jit.si/http-bind',
+        hosts: {
+            domain: 'meet.jit.si',
+            focus: 'focus.meet.jit.si',
+            muc: 'conference.meet.jit.si'
+        }
     }
-  }
-}
-
+};

--- a/features/base/lib-jitsi-meet/native/polyfills-browser.js
+++ b/features/base/lib-jitsi-meet/native/polyfills-browser.js
@@ -1,12 +1,12 @@
 /**
  * Gets the first common prototype of two specified Objects (treating the
- * Objects themselves as prototypes as well).
+ * objects themselves as prototypes as well).
  *
- * @param {Object} a - the first prototype chain to climb in search of a common
- *      prototype
- * @param {Object} b - the second prototype chain to climb in search of a common
- *      prototype
- * @returns {Object|undefined} - the first common prototype of a and b
+ * @param {Object} a - The first prototype chain to climb in search of a common
+ *      prototype.
+ * @param {Object} b - The second prototype chain to climb in search of a common
+ *      prototype.
+ * @returns {Object|undefined} - The first common prototype of a and b.
  */
 function _getCommonPrototype(a, b) {
     // Allow the arguments to be prototypes themselves.
@@ -31,10 +31,10 @@ function _getCommonPrototype(a, b) {
  * and Element.querySelector. Implements the most simple of selectors necessary
  * to satisfy the call sites at the time of this writing i.e. select by tagName.
  *
- * @param {Node} node - the Node which is the root of the tree to query
- * @param {string} selectors - the group of CSS selectors to match on
- * @returns {Element} - the first Element which is a descendant of the specified
- * node and matches the specified group of selectors
+ * @param {Node} node - The Node which is the root of the tree to query.
+ * @param {string} selectors - The group of CSS selectors to match on.
+ * @returns {Element} - The first Element which is a descendant of the specified
+ *      node and matches the specified group of selectors.
  */
 function _querySelector(node, selectors) {
     let element = null;
@@ -56,11 +56,11 @@ function _querySelector(node, selectors) {
  * Visits each Node in the tree of a specific root Node (using depth-first
  * traversal) and invokes a specific callback until the callback returns true.
  *
- * @param {Node} node - the root Node which represents the tree of Nodes to
- *      visit
- * @param {Function} callback - the callback to invoke with each visted Node
- * @returns {boolean} - true if the specified callback returned true for a Node;
- *      otherwise, false
+ * @param {Node} node - The root Node which represents the tree of Nodes to
+ *      visit.
+ * @param {Function} callback - The callback to invoke with each visited Node.
+ * @returns {boolean} - True if the specified callback returned true for a Node.
+ *      Otherwise, false.
  */
 function _visitNode(node, callback) {
     if (callback(node)) {

--- a/features/base/lib-jitsi-meet/native/polyfills-browser.js
+++ b/features/base/lib-jitsi-meet/native/polyfills-browser.js
@@ -2,9 +2,11 @@
  * Gets the first common prototype of two specified Objects (treating the
  * Objects themselves as prototypes as well).
  *
- * @param a the first prototype chain to climb in search of a common prototype
- * @param b the second prototype chain to climb in search of a common prototype
- * @return the first common prototype of a and b
+ * @param {Object} a - the first prototype chain to climb in search of a common
+ *      prototype
+ * @param {Object} b - the second prototype chain to climb in search of a common
+ *      prototype
+ * @returns {Object|undefined} - the first common prototype of a and b
  */
 function _getCommonPrototype(a, b) {
     // Allow the arguments to be prototypes themselves.
@@ -31,7 +33,7 @@ function _getCommonPrototype(a, b) {
  *
  * @param {Node} node - the Node which is the root of the tree to query
  * @param {string} selectors - the group of CSS selectors to match on
- * @return {Element} the first Element which is a descendant of the specified
+ * @returns {Element} - the first Element which is a descendant of the specified
  * node and matches the specified group of selectors
  */
 function _querySelector(node, selectors) {
@@ -55,10 +57,10 @@ function _querySelector(node, selectors) {
  * traversal) and invokes a specific callback until the callback returns true.
  *
  * @param {Node} node - the root Node which represents the tree of Nodes to
- * visit
+ *      visit
  * @param {Function} callback - the callback to invoke with each visted Node
- * @return {boolean} true if the specified callback returned true for a Node;
- * otherwise, false
+ * @returns {boolean} - true if the specified callback returned true for a Node;
+ *      otherwise, false
  */
 function _visitNode(node, callback) {
     if (callback(node)) {

--- a/features/base/lib-jitsi-meet/native/polyfills-webrtc.js
+++ b/features/base/lib-jitsi-meet/native/polyfills-webrtc.js
@@ -20,13 +20,17 @@
         // lib-jitsi-meet which has been successfully running on Chrome,
         // Firefox, Temasys, etc. for a very long time, attempt to meets its
         // expectations (by extending RTCPPeerConnection).
-        // XXX At the time of this writing extending RTCPeerConnection using ES6
-        // 'class' and 'extends' causes a runtime error related to the attemp to
-        // define the onaddstream property setter. The error mentions that
-        // babelHelpers.set is undefined which appears to be a thing inside
-        // React Native's packager. As a workaround, extend using the pre-ES6
-        // way.
-        // eslint-disable-next-line no-inner-declarations
+        /*eslint-disable no-inner-declarations */
+        /**
+         * At the time of this writing extending RTCPeerConnection using ES6
+         * 'class' and 'extends' causes a runtime error related to the attempt
+         * to define the onaddstream property setter. The error mentions that
+         * babelHelpers.set is undefined which appears to be a thing inside
+         * React Native's packager. As a workaround, extend using the pre-ES6
+         * way.
+         *
+         * @class
+         * */
         function _RTCPeerConnection() {
             RTCPeerConnection.apply(this, arguments);
 
@@ -53,6 +57,7 @@
                 }
             });
         }
+        /*eslint-enable no-inner-declarations */
 
         _RTCPeerConnection.prototype =
             Object.create(RTCPeerConnection.prototype);

--- a/features/base/media/components/native/Audio.js
+++ b/features/base/media/components/native/Audio.js
@@ -7,6 +7,7 @@ import React, { Component } from 'react';
 export class Audio extends Component {
     /**
      * Implements React Component's render method.
+     * 
      * @inheritdoc
      * @returns {null}
      */

--- a/features/base/media/components/native/Audio.js
+++ b/features/base/media/components/native/Audio.js
@@ -1,11 +1,15 @@
 import React, { Component } from 'react';
-import { RTCView } from 'react-native-webrtc';
 
 /**
  * The React Native component which is similar to Web's audio element and wraps
  * around react-native-webrtc's RTCView.
  */
 export class Audio extends Component {
+    /**
+     * Implements React Component's render method.
+     * @inheritdoc
+     * @returns {null}
+     */
     render() {
         // TODO react-native-webrtc's RTCView doesn't do anything with the audio
         // MediaStream specified to it so it's easier at the time of this
@@ -14,6 +18,9 @@ export class Audio extends Component {
     }
 }
 
+/**
+ * Component's prop types.
+ */
 Audio.propTypes = {
     stream: React.PropTypes.object,
     muted: React.PropTypes.bool

--- a/features/base/media/components/native/Video.js
+++ b/features/base/media/components/native/Video.js
@@ -10,6 +10,7 @@ import styles from './styles/Styles';
 export class Video extends Component {
     /**
      * React Component method that executes once component is mounted.
+     *
      * @inheritdoc
      */
     componentDidMount() {
@@ -22,6 +23,7 @@ export class Video extends Component {
 
     /**
      * React Component render method.
+     * 
      * @inheritdoc
      * @returns {*}
      */

--- a/features/base/media/components/native/Video.js
+++ b/features/base/media/components/native/Video.js
@@ -8,6 +8,10 @@ import styles from './styles/Styles';
  * around react-native-webrtc's RTCView.
  */
 export class Video extends Component {
+    /**
+     * React Component method that executes once component is mounted.
+     * @inheritdoc
+     */
     componentDidMount() {
         // RTCView currently does not support media events, so just fire
         // onPlaying callback when <RTCView> is rendered.
@@ -16,6 +20,11 @@ export class Video extends Component {
         }
     }
 
+    /**
+     * React Component render method.
+     * @inheritdoc
+     * @returns {*}
+     */
     render() {
         let stream = this.props.stream;
 

--- a/features/base/media/components/web/Audio.js
+++ b/features/base/media/components/web/Audio.js
@@ -8,8 +8,9 @@ export class Audio extends Component {
     /**
      * Implements shouldComponentUpdate of React Component. We don't update 
      * component if stream has not changed.
-     * @inhertidoc
-     * @param {Object} nextProps
+     *
+     * @inheritdoc
+     * @param {Object} nextProps - Props that component is going to receive.
      * @returns {boolean}
      */
     shouldComponentUpdate(nextProps) {
@@ -18,6 +19,7 @@ export class Audio extends Component {
 
     /**
      * Implements React Component's render method.
+     *
      * @inheritdoc
      * @returns {XML} - JSX markup.
      */

--- a/features/base/media/components/web/Audio.js
+++ b/features/base/media/components/web/Audio.js
@@ -1,10 +1,26 @@
 import React, { Component } from 'react';
 
+/**
+ * React-Native version of Audio component.
+ * @extends Component
+ */
 export class Audio extends Component {
+    /**
+     * Implements shouldComponentUpdate of React Component. We don't update 
+     * component if stream has not changed.
+     * @inhertidoc
+     * @param {Object} nextProps
+     * @returns {boolean}
+     */
     shouldComponentUpdate(nextProps) {
         return (nextProps.stream || {}).id !== (this.props.stream || {}).id;
     }
 
+    /**
+     * Implements React Component's render method.
+     * @inheritdoc
+     * @returns {XML} - JSX markup.
+     */
     render() {
         // TODO: use URL.releaseObjectURL on componentDid/WillUnmount
         let src = this.props.stream
@@ -20,6 +36,9 @@ export class Audio extends Component {
     }
 }
 
+/**
+ * PropTypes for component.
+ */
 Audio.propTypes = {
     stream: React.PropTypes.object,
     muted: React.PropTypes.bool

--- a/features/base/media/components/web/Video.js
+++ b/features/base/media/components/web/Video.js
@@ -8,8 +8,9 @@ export class Video extends Component {
     /**
      * Implements shouldComponentUpdate of React Component. We don't update
      * component if stream has not changed.
-     * @inhertidoc
-     * @param {Object} nextProps
+     *
+     * @inheritdoc
+     * @param {Object} nextProps - Props that component is going to receive.
      * @returns {boolean}
      */
     shouldComponentUpdate(nextProps) {
@@ -18,6 +19,7 @@ export class Video extends Component {
 
     /**
      * Implements React Component's render method.
+     * 
      * @inheritdoc
      * @returns {XML} - JSX markup.
      */

--- a/features/base/media/components/web/Video.js
+++ b/features/base/media/components/web/Video.js
@@ -1,10 +1,26 @@
 import React, { Component } from 'react';
 
+/**
+ * Web version of Audio component.
+ * @extends Component
+ */
 export class Video extends Component {
+    /**
+     * Implements shouldComponentUpdate of React Component. We don't update
+     * component if stream has not changed.
+     * @inhertidoc
+     * @param {Object} nextProps
+     * @returns {boolean}
+     */
     shouldComponentUpdate(nextProps) {
         return (nextProps.stream || {}).id !== (this.props.stream || {}).id;
     }
 
+    /**
+     * Implements React Component's render method.
+     * @inheritdoc
+     * @returns {XML} - JSX markup.
+     */
     render() {
         // TODO: use URL.releaseObjectURL on componentDid/WillUnmount
         let src = this.props.stream
@@ -21,6 +37,9 @@ export class Video extends Component {
     }
 }
 
+/**
+ * PropTypes for component.
+ */
 Video.propTypes = {
     stream: React.PropTypes.object,
     muted: React.PropTypes.bool,

--- a/features/base/navigation/actions.js
+++ b/features/base/navigation/actions.js
@@ -1,10 +1,21 @@
 import { APP_NAVIGATE } from './actionTypes';
 
+// TODO: change screen param to enum when navigation is extracted into separate
+// feature
 /**
  * Trigger an in-app navigation to a different screen.
- *
  * Using this action allows for navigation to be abstracted between the mobile
  * and web versions.
+ * @param {Object} opts
+ * @param {Navigator} opts.navigator
+ * @param {string} opts.room
+ * @param {string} opts.screen
+ * @returns {{
+ *      type: APP_NAVIGATE,
+ *      navigator: Navigator,
+ *      room: string,
+ *      screen: string
+ * }}
  */
 export function navigate(opts) {
     return {

--- a/features/base/navigation/actions.js
+++ b/features/base/navigation/actions.js
@@ -6,10 +6,11 @@ import { APP_NAVIGATE } from './actionTypes';
  * Trigger an in-app navigation to a different screen.
  * Using this action allows for navigation to be abstracted between the mobile
  * and web versions.
- * @param {Object} opts
- * @param {Navigator} opts.navigator
- * @param {string} opts.room
- * @param {string} opts.screen
+ *
+ * @param {Object} opts - Navigation options.
+ * @param {Navigator} opts.navigator - Navigator instance.
+ * @param {string} opts.room - Conference room name.
+ * @param {string} opts.screen - Name of state/screen to switch to.
  * @returns {{
  *      type: APP_NAVIGATE,
  *      navigator: Navigator,

--- a/features/base/participants/actions.js
+++ b/features/base/participants/actions.js
@@ -27,11 +27,11 @@ export function dominantSpeakerChanged(id) {
 /**
  * Action to create a local user.
  * @param {string} id - user id
- * @param {Object} user={}
- * @param {string} (user.displayName='me')
- * @param {string} (user.avatar='')
- * @param {string} (user.role='none')
- * @returns {Object}
+ * @param {Object} [user={}]
+ * @param {string} [user.displayName='me']
+ * @param {string} [user.avatar='']
+ * @param {string} [user.role='none']
+ * @returns {Function}
  */
 export function localParticipantJoined(id, user = {}) {
     return (dispatch, getState) => {
@@ -53,13 +53,18 @@ export function localParticipantJoined(id, user = {}) {
                     : undefined
             }
         });
-    }
+    };
 }
 
 /**
  * Create an action for when the user in conference is focused.
  * @param {string|null} id - user id
- * @returns {Object}
+ * @returns {{
+ *      type: PARTICIPANT_FOCUSED,
+ *      participant: {
+ *          id: string
+ *      }
+ * }}
  */
 export function participantFocused(id) {
     return {
@@ -73,7 +78,12 @@ export function participantFocused(id) {
 /**
  * Action to handle case when participant lefts.
  * @param {string} id - user id
- * @returns {Object}
+ * @returns {{
+ *      type: PARTICIPANT_REMOVED,
+ *      participant: {
+ *          id: string
+ *      }
+ * }}
  */
 export function participantLeft(id) {
     return {
@@ -87,7 +97,7 @@ export function participantLeft(id) {
 /**
  * Create an action for when the user in conference is pinned.
  * @param {string|null} id - user id
- * @returns {Object}
+ * @returns {Function}
  */
 export function participantPinned(id) {
     return (dispatch, getState) => {
@@ -119,7 +129,13 @@ export function participantPinned(id) {
  * Action to handle case when participant's role changes.
  * @param {string} id - user id
  * @param {string} role - new user role
- * @returns {Object}
+ * @returns {{
+ *      type: PARTICIPANT_UPDATED,
+ *      participant: {
+ *          id: string,
+ *          role: string
+ *      }
+ * }}
  */
 export function participantRoleChanged(id, role) {
     return {
@@ -134,7 +150,7 @@ export function participantRoleChanged(id, role) {
 /**
  * Create an action for when the user in conference is selected.
  * @param {string|null} id - user id
- * @returns {Object}
+ * @returns {Function}
  */
 export function participantSelected(id) {
     return (dispatch, getState) => {
@@ -154,7 +170,13 @@ export function participantSelected(id) {
 /**
  * Create an action for when the user's video started to play.
  * @param {string} id - user id
- * @returns {Object}
+ * @returns {{
+ *      type: PARTICIPANT_UPDATED,
+ *      participant: {
+ *          id: string,
+ *          videoStarted: boolean
+ *      }
+ * }}
  */
 export function participantVideoStarted(id) {
     return {
@@ -169,12 +191,12 @@ export function participantVideoStarted(id) {
 /**
  * Create an action for when participant video type changes.
  * @param {string} id - user id
- * @param {'camera'|'desktop'} videoType - video type
+ * @param {string} videoType - video type
  * @returns {{
  *      type: PARTICIPANT_UPDATED,
  *      participant: {
  *          id: string,
- *          videoType: 'camera'|'desktop'
+ *          videoType: string
  *      }
  * }}
  */
@@ -191,11 +213,19 @@ export function participantVideoTypeChanged(id, videoType) {
 /**
  * Action to create a remote user.
  * @param {string} id - user id
- * @param {Object} user={}
- * @param {string} (user.displayName='Fellow Jitster')
- * @param {string} (user.avatar='')
- * @param {string} (user.role='none')
- * @returns {Object}
+ * @param {Object} [user={}]
+ * @param {string} [user.displayName='Fellow Jitster']
+ * @param {string} [user.avatar='']
+ * @param {string} [user.role='none']
+ * @returns {{
+ *      type: PARTICIPANT_ADDED,
+ *      participant: {
+ *          id: string,
+ *          name: string,
+ *          avatar: string,
+ *          role: string
+ *      }
+ *  }}
  */
 export function remoteParticipantJoined(id, user = {}) {
     return {

--- a/features/base/participants/actions.js
+++ b/features/base/participants/actions.js
@@ -12,7 +12,8 @@ import './reducer';
 
 /**
  * Create an action for when dominant speaker changes.
- * @param {string} id - user id
+ *
+ * @param {string} id - User id.
  * @returns {Object}
  */
 export function dominantSpeakerChanged(id) {
@@ -26,11 +27,12 @@ export function dominantSpeakerChanged(id) {
 
 /**
  * Action to create a local user.
- * @param {string} id - user id
- * @param {Object} [user={}]
- * @param {string} [user.displayName='me']
- * @param {string} [user.avatar='']
- * @param {string} [user.role='none']
+ *
+ * @param {string} id - User id.
+ * @param {Object} [user={}] - Additional information about user.
+ * @param {string} [user.displayName='me'] - User's display name.
+ * @param {string} [user.avatar=''] - User's avatar.
+ * @param {string} [user.role='none'] - User's role.
  * @returns {Function}
  */
 export function localParticipantJoined(id, user = {}) {
@@ -58,7 +60,9 @@ export function localParticipantJoined(id, user = {}) {
 
 /**
  * Create an action for when the user in conference is focused.
- * @param {string|null} id - user id
+ *
+ * @param {string|null} id - User id. If null is passed, means no one is
+ *      currently focused.
  * @returns {{
  *      type: PARTICIPANT_FOCUSED,
  *      participant: {
@@ -77,7 +81,8 @@ export function participantFocused(id) {
 
 /**
  * Action to handle case when participant lefts.
- * @param {string} id - user id
+ *
+ * @param {string} id - User id.
  * @returns {{
  *      type: PARTICIPANT_REMOVED,
  *      participant: {
@@ -96,7 +101,9 @@ export function participantLeft(id) {
 
 /**
  * Create an action for when the user in conference is pinned.
- * @param {string|null} id - user id
+ *
+ * @param {string|null} id - User id. If null is passed, no one is currently
+ *      pinned.
  * @returns {Function}
  */
 export function participantPinned(id) {
@@ -127,8 +134,9 @@ export function participantPinned(id) {
 
 /**
  * Action to handle case when participant's role changes.
- * @param {string} id - user id
- * @param {string} role - new user role
+ *
+ * @param {string} id - User id.
+ * @param {string} role - User's new role.
  * @returns {{
  *      type: PARTICIPANT_UPDATED,
  *      participant: {
@@ -149,7 +157,8 @@ export function participantRoleChanged(id, role) {
 
 /**
  * Create an action for when the user in conference is selected.
- * @param {string|null} id - user id
+ *
+ * @param {string|null} id - User id. If null, no one is selected.
  * @returns {Function}
  */
 export function participantSelected(id) {
@@ -169,7 +178,8 @@ export function participantSelected(id) {
 
 /**
  * Create an action for when the user's video started to play.
- * @param {string} id - user id
+ *
+ * @param {string} id - User id.
  * @returns {{
  *      type: PARTICIPANT_UPDATED,
  *      participant: {
@@ -190,8 +200,9 @@ export function participantVideoStarted(id) {
 
 /**
  * Create an action for when participant video type changes.
- * @param {string} id - user id
- * @param {string} videoType - video type
+ *
+ * @param {string} id - User id.
+ * @param {string} videoType - Video type ('desktop' or 'camera').
  * @returns {{
  *      type: PARTICIPANT_UPDATED,
  *      participant: {
@@ -212,11 +223,12 @@ export function participantVideoTypeChanged(id, videoType) {
 
 /**
  * Action to create a remote user.
- * @param {string} id - user id
- * @param {Object} [user={}]
- * @param {string} [user.displayName='Fellow Jitster']
- * @param {string} [user.avatar='']
- * @param {string} [user.role='none']
+ *
+ * @param {string} id - User id.
+ * @param {Object} [user={}] - Additional information about user.
+ * @param {string} [user.displayName='Fellow Jitster'] - User's display name.
+ * @param {string} [user.avatar=''] - User's avatar.
+ * @param {string} [user.role='none'] - User's role.
  * @returns {{
  *      type: PARTICIPANT_ADDED,
  *      participant: {

--- a/features/base/participants/reducer.js
+++ b/features/base/participants/reducer.js
@@ -14,23 +14,23 @@ import {
 /**
  * Participant object.
  * @typedef {Object} Participant
- * @property {string} id - participant ID.
- * @property {string} name - participant name.
- * @property {string} avatar - path to participant avatar if any.
- * @property {string} role - participant role.
- * @property {boolean} local - if true, participant is local.
- * @property {boolean} pinned - if true, participant is current
+ * @property {string} id - Participant ID.
+ * @property {string} name - Participant name.
+ * @property {string} avatar - Path to participant avatar if any.
+ * @property {string} role - Participant role.
+ * @property {boolean} local - If true, participant is local.
+ * @property {boolean} pinned - If true, participant is current
  *      "PINNED_ENDPOINT".
- * @property {boolean} speaking - if true, participant is currently a
+ * @property {boolean} speaking - If true, participant is currently a
  *      dominant speaker.
- * @property {boolean} focused - if true, participant is currently visually
+ * @property {boolean} focused - If true, participant is currently visually
  *      selected on UI.
- * @property {boolean} selected - if true, participant is current
+ * @property {boolean} selected - If true, participant is current
  *      "SELECTED_ENDPOINT".
- * @property {boolean} videoStarted -  if true, participant video stream has
+ * @property {boolean} videoStarted -  If true, participant video stream has
  *      already started.
- * @property {'camera'|'desktop'|undefined} videoType - type of participant's
- *      current video stream.
+ * @property {('camera'|'desktop'|undefined)} videoType - Type of participant's
+ *      current video stream if any.
  */
 
 /**
@@ -42,12 +42,14 @@ const PARTICIPANT_PROPS_TO_OMIT_WHEN_UPDATE = [
     'id', 'local', 'pinned', 'speaking', 'focused'];
 
 /**
-* Actions for a single participant.
-* @param {Participant|undefined} state
-* @param {Object} action
-* @param {string} action.type
-* @param {Participant} action.participant
-* @returns {Participant|undefined}
+ * Reducer function for a single participant.
+ *
+ * @param {Participant|undefined} state - Participant to be modified.
+ * @param {Object} action - Action object.
+ * @param {string} action.type - Type of action.
+ * @param {Participant} action.participant - Information about participant to be
+ *      added/modified.
+ * @returns {Participant|undefined}
  */
 function participant(state, action) {
     switch (action.type) {
@@ -115,14 +117,16 @@ function participant(state, action) {
 }
 
 /**
-* Listen for actions which add, remove, or update the set of participants
-* in the conference.
-* @param {Participant[]} state
-* @param {Object} action
-* @param {string} action.type
-* @param {Participant} action.participant
-* @returns {Participant[]}
-*/
+ * Listen for actions which add, remove, or update the set of participants
+ * in the conference.
+ *
+ * @param {Participant[]} state - List of participants to be modified.
+ * @param {Object} action - Action object.
+ * @param {string} action.type - Type of action.
+ * @param {Participant} action.participant - Information about participant to be
+ *      added/removed/modified.
+ * @returns {Participant[]}
+ */
 ReducerRegistry.register('features/base/participants', (state = [], action) => {
     switch (action.type) {
     case PARTICIPANT_ADDED:

--- a/features/base/redux/ReducerRegistry.js
+++ b/features/base/redux/ReducerRegistry.js
@@ -5,11 +5,8 @@ import { combineReducers } from 'redux';
  * without needing to create additional inter-feature dependencies.
  */
 class ReducerRegistry {
-
     /**
      * Creates a ReducerRegistry instance.
-     *
-     * @constructor
      */
     constructor() {
         /**
@@ -22,8 +19,8 @@ class ReducerRegistry {
     /**
      * Combines all registered reducers into a single reducing function.
      *
-     * @param {Object} additional = {} - Any additional reducers that need to be
-     * included (such as reducers from third-party modules).
+     * @param {Object} [additional={}] - Any additional reducers that need to be
+     *      included (such as reducers from third-party modules).
      * @returns {Function}
      */
     combineReducers(additional = {}) {
@@ -37,8 +34,8 @@ class ReducerRegistry {
      * Adds a reducer to the registry.
      *
      * @param {string} name - The field in the state object that will be managed
-     * by the provided reducer.
-     * @param {Function} reducer - A Redux reducer
+     *      by the provided reducer.
+     * @param {Function} reducer - A Redux reducer.
      * @returns {void}
      */
     register(name, reducer) {

--- a/features/base/redux/ReducerRegistry.js
+++ b/features/base/redux/ReducerRegistry.js
@@ -22,8 +22,9 @@ class ReducerRegistry {
     /**
      * Combines all registered reducers into a single reducing function.
      *
-     * @param {object} additional = {} - Any additional reducers that need to be
+     * @param {Object} additional = {} - Any additional reducers that need to be
      * included (such as reducers from third-party modules).
+     * @returns {Function}
      */
     combineReducers(additional = {}) {
         return combineReducers({
@@ -37,7 +38,8 @@ class ReducerRegistry {
      *
      * @param {string} name - The field in the state object that will be managed
      * by the provided reducer.
-     * @param reducer {Function} A Redux reducer
+     * @param {Function} reducer - A Redux reducer
+     * @returns {void}
      */
     register(name, reducer) {
         this.reducerRegistry[name] = reducer;

--- a/features/base/tracks/actions.js
+++ b/features/base/tracks/actions.js
@@ -14,6 +14,9 @@ require('./reducer');
 
 /**
  * Attach a set of local tracks to a conference.
+ * @param {JitsiConference} conference
+ * @param {JitsiLocalTrack[]} localTracks
+ * @returns {void}
  */
 export function addTracksToConference(conference, localTracks) {
     let conferenceLocalTracks = conference.getLocalTracks();
@@ -30,6 +33,7 @@ export function addTracksToConference(conference, localTracks) {
  * Add new local tracks to the conference, replacing any existing tracks
  * that were previously attached.
  * @param {JitsiLocalTrack[]} newLocalTracks=[]
+ * @returns {Function}
  */
 export function changeLocalTracks(newLocalTracks = []) {
     return (dispatch, getState) => {
@@ -103,7 +107,8 @@ export function changeLocalTracks(newLocalTracks = []) {
  * Request to start capturing local audio and/or video.
  * By default, the user facing camera will be selected.
  *
- * @param {object} (options) - @see options for JitsiMeetJS.createLocalTracks
+ * @param {Object} [options] - @see JitsiMeetJS.createLocalTracks
+ * @returns {Function}
  */
 export function createLocalTracks(options) {
     options || (options = {});

--- a/features/base/tracks/actions.js
+++ b/features/base/tracks/actions.js
@@ -14,8 +14,9 @@ require('./reducer');
 
 /**
  * Attach a set of local tracks to a conference.
- * @param {JitsiConference} conference
- * @param {JitsiLocalTrack[]} localTracks
+ *
+ * @param {JitsiConference} conference - Conference instance.
+ * @param {JitsiLocalTrack[]} localTracks - List of local media tracks.
  * @returns {void}
  */
 export function addTracksToConference(conference, localTracks) {
@@ -32,7 +33,9 @@ export function addTracksToConference(conference, localTracks) {
 /**
  * Add new local tracks to the conference, replacing any existing tracks
  * that were previously attached.
- * @param {JitsiLocalTrack[]} newLocalTracks=[]
+ *
+ * @param {JitsiLocalTrack[]} [newLocalTracks=[]] - List of new local media
+ *      tracks.
  * @returns {Function}
  */
 export function changeLocalTracks(newLocalTracks = []) {
@@ -107,7 +110,7 @@ export function changeLocalTracks(newLocalTracks = []) {
  * Request to start capturing local audio and/or video.
  * By default, the user facing camera will be selected.
  *
- * @param {Object} [options] - @see JitsiMeetJS.createLocalTracks
+ * @param {Object} [options] - For info @see JitsiMeetJS.createLocalTracks.
  * @returns {Function}
  */
 export function createLocalTracks(options) {
@@ -131,7 +134,8 @@ export function createLocalTracks(options) {
 /**
  * Create an action for when a new track has been signaled to be added
  * to the conference.
- * @param {JitsiTrack} track
+ *
+ * @param {JitsiTrack} track - JitsiTrack instance.
  * @returns {{ type: TRACK_ADDED, track: JitsiTrack }}
  */
 export function trackAdded(track) {
@@ -144,7 +148,8 @@ export function trackAdded(track) {
 /**
  * Create an action for when a track has been signaled for
  * removal from the conference.
- * @param {JitsiTrack} track
+ *
+ * @param {JitsiTrack} track - JitsiTrack instance.
  * @returns {{ type: TRACK_REMOVED, track: JitsiTrack }}
  */
 export function trackRemoved(track) {

--- a/features/conference/components/Conference.js
+++ b/features/conference/components/Conference.js
@@ -10,6 +10,11 @@ import { ConferenceContainer } from './_';
  * The conference page for the application.
  */
 class Conference extends Component {
+    /**
+     * Implements React Component's render method.
+     * @inheritdoc
+     * @returns {XML}
+     */
     render() {
         return (
             <ConferenceContainer>
@@ -22,6 +27,7 @@ class Conference extends Component {
 }
 
 /**
+ * Component's prop types.
  * Ensure that the application navigator object is passed down via props
  * on mobile.
  */

--- a/features/conference/components/Conference.js
+++ b/features/conference/components/Conference.js
@@ -12,6 +12,7 @@ import { ConferenceContainer } from './_';
 class Conference extends Component {
     /**
      * Implements React Component's render method.
+     * 
      * @inheritdoc
      * @returns {XML}
      */

--- a/features/conference/components/native/ConferenceContainer.js
+++ b/features/conference/components/native/ConferenceContainer.js
@@ -9,6 +9,7 @@ import styles from './styles/Styles';
 export class ConferenceContainer extends Component {
     /**
      * Implements React Component's render method.
+     * 
      * @inheritdoc
      * @returns {XML}
      */

--- a/features/conference/components/native/ConferenceContainer.js
+++ b/features/conference/components/native/ConferenceContainer.js
@@ -7,6 +7,11 @@ import styles from './styles/Styles';
  * The native container rendering the conference view.
  */
 export class ConferenceContainer extends Component {
+    /**
+     * Implements React Component's render method.
+     * @inheritdoc
+     * @returns {XML}
+     */
     render() {
         return (
             <View style = { styles.conference }>{ this.props.children }</View>
@@ -14,6 +19,9 @@ export class ConferenceContainer extends Component {
     }
 }
 
+/**
+ * Prop types for component.
+ */
 ConferenceContainer.propTypes = {
-    children: React.PropTypes.element
+    children: React.PropTypes.node
 };

--- a/features/conference/components/web/ConferenceContainer.js
+++ b/features/conference/components/web/ConferenceContainer.js
@@ -6,6 +6,7 @@ import React, { Component } from 'react';
 export class ConferenceContainer extends Component {
     /**
      * Implements React Component's render method.
+     * 
      * @inheritdoc
      * @returns {XML}
      */

--- a/features/conference/components/web/ConferenceContainer.js
+++ b/features/conference/components/web/ConferenceContainer.js
@@ -4,6 +4,11 @@ import React, { Component } from 'react';
  * The web container rendering the conference view.
  */
 export class ConferenceContainer extends Component {
+    /**
+     * Implements React Component's render method.
+     * @inheritdoc
+     * @returns {XML}
+     */
     render() {
         return (
             <div>{this.props.children}</div>
@@ -11,6 +16,9 @@ export class ConferenceContainer extends Component {
     }
 }
 
+/**
+ * Prop types for component.
+ */
 ConferenceContainer.propTypes = {
-    children: React.PropTypes.element
+    children: React.PropTypes.node
 };

--- a/features/filmStrip/components/FilmStrip.js
+++ b/features/filmStrip/components/FilmStrip.js
@@ -11,6 +11,7 @@ import { FilmStripContainer } from './_';
 class FilmStrip extends Component {
     /**
      * React component render method.
+     *
      * @inheritdoc
      */
     render() {
@@ -51,10 +52,11 @@ class FilmStrip extends Component {
 
 /**
  * Function that maps parts of Redux state tree into component props.
- * @param {Object} state
+ *
+ * @param {Object} state - Redux state.
  * @returns {{
- *  participants: Participant[],
- *  tracks: (JitsiLocalTrack|JitsiRemoteTrack)[]
+ *      participants: Participant[],
+ *      tracks: (JitsiLocalTrack|JitsiRemoteTrack)[]
  *  }}
  */
 const mapStateToProps = state => {
@@ -66,6 +68,7 @@ const mapStateToProps = state => {
 
 /**
  * React PropTypes for FilmStrip component.
+ *
  * @static
  */
 FilmStrip.propTypes = {

--- a/features/filmStrip/components/FilmStrip.js
+++ b/features/filmStrip/components/FilmStrip.js
@@ -45,7 +45,7 @@ class FilmStrip extends Component {
                         })
                 }
             </FilmStripContainer>
-        )
+        );
     }
 }
 

--- a/features/filmStrip/components/VideoThumbnail.js
+++ b/features/filmStrip/components/VideoThumbnail.js
@@ -18,7 +18,8 @@ class VideoThumbnail extends Component {
     /**
      * Handles click/tap event on the thumbnail. Prevents further event
      * propagation.
-     * @param {Event} event
+     *
+     * @param {Event} event - DOM event.
      * @returns {false}
      */
     onClickHandler(event) {
@@ -37,6 +38,7 @@ class VideoThumbnail extends Component {
 
     /**
      * Processes click on video thumbnail.
+     *
      * @returns {void}
      */
     handleVideoThumbClicked () {
@@ -54,6 +56,7 @@ class VideoThumbnail extends Component {
 
     /**
      * Handler for case when video starts to play.
+     *
      * @returns {void}
      */
     onVideoPlayingHandler() {
@@ -62,6 +65,7 @@ class VideoThumbnail extends Component {
 
     /**
      * Returns audio and video media streams for participant.
+     *
      * @returns {{ video: (MediaStream|null), audio: (MediaStream|null) }}
      */
     getMediaStreams() {
@@ -77,6 +81,7 @@ class VideoThumbnail extends Component {
 
     /**
      * React component render method.
+     *
      * @inheritdoc
      * @returns {XML}
      */
@@ -99,6 +104,7 @@ class VideoThumbnail extends Component {
 
 /**
  * React PropTypes for VideoThumbnail component.
+ * 
  * @static
  */
 VideoThumbnail.propTypes = {

--- a/features/filmStrip/components/VideoThumbnail.js
+++ b/features/filmStrip/components/VideoThumbnail.js
@@ -16,8 +16,10 @@ import { VideoThumbnailContainer } from './_';
  */
 class VideoThumbnail extends Component {
     /**
-     * Handles click/tap event on the thumbnail.
+     * Handles click/tap event on the thumbnail. Prevents further event
+     * propagation.
      * @param {Event} event
+     * @returns {false}
      */
     onClickHandler(event) {
         this.handleVideoThumbClicked();
@@ -35,6 +37,7 @@ class VideoThumbnail extends Component {
 
     /**
      * Processes click on video thumbnail.
+     * @returns {void}
      */
     handleVideoThumbClicked () {
         // TODO: this currently ignores interfaceConfig.filmStripOnly
@@ -51,6 +54,7 @@ class VideoThumbnail extends Component {
 
     /**
      * Handler for case when video starts to play.
+     * @returns {void}
      */
     onVideoPlayingHandler() {
         this.props.dispatch(participantVideoStarted(this.props.participant.id));
@@ -58,7 +62,7 @@ class VideoThumbnail extends Component {
 
     /**
      * Returns audio and video media streams for participant.
-     * @returns {{ video: MediaStream|null, audio: MediaStream|null }}
+     * @returns {{ video: (MediaStream|null), audio: (MediaStream|null) }}
      */
     getMediaStreams() {
         return {
@@ -74,6 +78,7 @@ class VideoThumbnail extends Component {
     /**
      * React component render method.
      * @inheritdoc
+     * @returns {XML}
      */
     render() {
         let streams = this.getMediaStreams();
@@ -99,7 +104,8 @@ class VideoThumbnail extends Component {
 VideoThumbnail.propTypes = {
     participant: React.PropTypes.object,
     audioTrack: React.PropTypes.object,
-    videoTrack: React.PropTypes.object
+    videoTrack: React.PropTypes.object,
+    dispatch: React.PropTypes.func
 };
 
 export default connect()(VideoThumbnail);

--- a/features/filmStrip/components/native/FilmStripContainer.js
+++ b/features/filmStrip/components/native/FilmStripContainer.js
@@ -9,6 +9,7 @@ import styles from './styles/Styles';
 export class FilmStripContainer extends Component {
     /**
      * React component render method.
+     * 
      * @inheritdoc
      * @returns {XML}
      */

--- a/features/filmStrip/components/native/FilmStripContainer.js
+++ b/features/filmStrip/components/native/FilmStripContainer.js
@@ -7,6 +7,11 @@ import styles from './styles/Styles';
  * The native container rendering the video thumbnails.
  */
 export class FilmStripContainer extends Component {
+    /**
+     * React component render method.
+     * @inheritdoc
+     * @returns {XML}
+     */
     render() {
         return (
             <View style = { styles.filmStrip }>{ this.props.children }</View>
@@ -15,5 +20,5 @@ export class FilmStripContainer extends Component {
 }
 
 FilmStripContainer.propTypes = {
-    children: React.PropTypes.element
+    children: React.PropTypes.node
 };

--- a/features/filmStrip/components/native/VideoThumbnailContainer.js
+++ b/features/filmStrip/components/native/VideoThumbnailContainer.js
@@ -4,9 +4,15 @@ import { TouchableHighlight, View } from 'react-native';
 import styles from './styles/Styles';
 
 /**
- * The video thumbnail native container.
+ * Web version of Video Thumbnail Container component.
+ * @extends Component
  */
 export class VideoThumbnailContainer extends Component {
+    /**
+     * Implements React Component's render method.
+     * @inheritdoc
+     * @returns {XML} - JSX markup.
+     */
     render() {
         return (
             <TouchableHighlight onPress={this.props.onClick}>
@@ -20,3 +26,13 @@ export class VideoThumbnailContainer extends Component {
         );
     }
 }
+
+/**
+ * React PropTypes for VideoThumbnailContainer component.
+ * @static
+ */
+VideoThumbnailContainer.propTypes = {
+    onClick: React.PropTypes.func,
+    focused: React.PropTypes.bool,
+    children: React.PropTypes.node
+};

--- a/features/filmStrip/components/native/VideoThumbnailContainer.js
+++ b/features/filmStrip/components/native/VideoThumbnailContainer.js
@@ -10,6 +10,7 @@ import styles from './styles/Styles';
 export class VideoThumbnailContainer extends Component {
     /**
      * Implements React Component's render method.
+     *
      * @inheritdoc
      * @returns {XML} - JSX markup.
      */
@@ -29,6 +30,7 @@ export class VideoThumbnailContainer extends Component {
 
 /**
  * React PropTypes for VideoThumbnailContainer component.
+ * 
  * @static
  */
 VideoThumbnailContainer.propTypes = {

--- a/features/filmStrip/components/web/FilmStripContainer.js
+++ b/features/filmStrip/components/web/FilmStripContainer.js
@@ -8,6 +8,7 @@ import styles from './styles/Styles';
 export class FilmStripContainer extends Component {
     /**
      * React component render method.
+     * 
      * @inheritdoc
      * @returns {XML}
      */

--- a/features/filmStrip/components/web/FilmStripContainer.js
+++ b/features/filmStrip/components/web/FilmStripContainer.js
@@ -6,6 +6,11 @@ import styles from './styles/Styles';
  * The web container rendering the video thumbnails.
  */
 export class FilmStripContainer extends Component {
+    /**
+     * React component render method.
+     * @inheritdoc
+     * @returns {XML}
+     */
     render() {
         return (
             <div style = { styles.filmStrip }>{ this.props.children }</div>
@@ -14,5 +19,5 @@ export class FilmStripContainer extends Component {
 }
 
 FilmStripContainer.propTypes = {
-    children: React.PropTypes.element
+    children: React.PropTypes.node
 };

--- a/features/filmStrip/components/web/VideoThumbnailContainer.js
+++ b/features/filmStrip/components/web/VideoThumbnailContainer.js
@@ -6,12 +6,17 @@ import { ColorPalette } from '../../../base/styles';
  * The video thumbnail web container.
  */
 export class VideoThumbnailContainer extends Component {
+    /**
+     * React component render method.
+     * @inheritdoc
+     * @returns {XML}
+     */
     render() {
         let styles = {};
 
         // TODO: this is temporary solution, discuss UI
         if (this.props.focused) {
-            styles.border = "5px solid " + ColorPalette.jitsiBlue;
+            styles.border = '5px solid ' + ColorPalette.jitsiBlue;
             /*
              .videoContainerFocused
              cursor: hand;
@@ -34,3 +39,13 @@ export class VideoThumbnailContainer extends Component {
         );
     }
 }
+
+/**
+ * React PropTypes for VideoThumbnailContainer component.
+ * @static
+ */
+VideoThumbnailContainer.propTypes = {
+    onClick: React.PropTypes.func,
+    focused: React.PropTypes.bool,
+    children: React.PropTypes.node
+};

--- a/features/filmStrip/components/web/VideoThumbnailContainer.js
+++ b/features/filmStrip/components/web/VideoThumbnailContainer.js
@@ -8,6 +8,7 @@ import { ColorPalette } from '../../../base/styles';
 export class VideoThumbnailContainer extends Component {
     /**
      * React component render method.
+     *
      * @inheritdoc
      * @returns {XML}
      */
@@ -42,6 +43,7 @@ export class VideoThumbnailContainer extends Component {
 
 /**
  * React PropTypes for VideoThumbnailContainer component.
+ * 
  * @static
  */
 VideoThumbnailContainer.propTypes = {

--- a/features/largeVideo/components/LargeVideo.js
+++ b/features/largeVideo/components/LargeVideo.js
@@ -12,8 +12,9 @@ import { LargeVideoContainer } from './_';
  */
 class LargeVideo extends Component {
     /**
-     * @constructor
-     * @param props
+     * Constructs new LargeVideo component.
+     *
+     * @param {Object} props
      */
     constructor(props) {
         super(props);
@@ -21,13 +22,13 @@ class LargeVideo extends Component {
         this.state = {
             videoStream: null,
             activeParticipant: null
-        }
+        };
     }
 
     /**
      * How we handle new component properties.
      * @inheritdoc
-     * @param nextProps
+     * @param {Object} nextProps
      */
     componentWillReceiveProps(nextProps) {
         let activeParticipant = getActiveParticipant(nextProps);
@@ -57,7 +58,7 @@ class LargeVideo extends Component {
         if (activeParticipant &&
             videoTrack &&
             !activeParticipant.selected &&
-            activeParticipant.videoType === "camera") {
+            activeParticipant.videoType === 'camera') {
             this.props.dispatch(participantSelected(activeParticipant.id));
         }
 
@@ -70,6 +71,7 @@ class LargeVideo extends Component {
     /**
      * React component render method implementation.
      * @inhertidoc
+     * @returns {XML}
      */
     render() {
         let videoStreamParticipant = getParticipantByVideoStream(
@@ -94,7 +96,7 @@ class LargeVideo extends Component {
 /**
  * Returns active participant to show.
  * @param {Object} props
- * @returns {Participant|undefined}
+ * @returns {(Participant|undefined)}
  */
 function getActiveParticipant(props) {
     // First get the focused participant.
@@ -119,7 +121,7 @@ function getActiveParticipant(props) {
  * @param {MediaStream} stream
  * @param {(JitsiLocalTrack|JitsiRemoteTrack)[]} tracks
  * @param {Object} participants
- * @returns {Object|undefined}
+ * @returns {(Object|undefined)}
  */
 function getParticipantByVideoStream(stream, tracks, participants) {
     if (!stream) {
@@ -141,7 +143,7 @@ function getParticipantByVideoStream(stream, tracks, participants) {
  * Returns video stream for a specified participant.
  * @param {Participant} participant
  * @param {(JitsiLocalTrack|JitsiRemoteTrack)[]} tracks
- * @returns {JitsiLocalTrack|JitsiRemoteTrack|undefined}
+ * @returns {(JitsiLocalTrack|JitsiRemoteTrack|undefined)}
  */
 function getVideoTrack(participant, tracks) {
     return tracks.find(t => {
@@ -154,7 +156,7 @@ function getVideoTrack(participant, tracks) {
 
 /**
  * Maps parts Redux state to Component's props.
- * @param state
+ * @param {Object} state
  * @returns {{
  *      tracks: (JitsiLocalTrack|JitsiRemoteTrack)[],
  *      participants: Participant[]
@@ -165,6 +167,12 @@ const mapStateToProps = state => {
         tracks: state['features/base/tracks'],
         participants: state['features/base/participants']
     };
+};
+
+LargeVideo.propTypes = {
+    tracks: React.PropTypes.array,
+    participants: React.PropTypes.array,
+    dispatch: React.PropTypes.func
 };
 
 export default connect(mapStateToProps)(LargeVideo);

--- a/features/largeVideo/components/LargeVideo.js
+++ b/features/largeVideo/components/LargeVideo.js
@@ -14,7 +14,7 @@ class LargeVideo extends Component {
     /**
      * Constructs new LargeVideo component.
      *
-     * @param {Object} props
+     * @param {Object} props - Component props.
      */
     constructor(props) {
         super(props);
@@ -27,8 +27,9 @@ class LargeVideo extends Component {
 
     /**
      * How we handle new component properties.
+     *
      * @inheritdoc
-     * @param {Object} nextProps
+     * @param {Object} nextProps - New props that component will receive.
      */
     componentWillReceiveProps(nextProps) {
         let activeParticipant = getActiveParticipant(nextProps);
@@ -70,7 +71,8 @@ class LargeVideo extends Component {
 
     /**
      * React component render method implementation.
-     * @inhertidoc
+     *
+     * @inheritdoc
      * @returns {XML}
      */
     render() {
@@ -95,7 +97,8 @@ class LargeVideo extends Component {
 
 /**
  * Returns active participant to show.
- * @param {Object} props
+ *
+ * @param {Object} props - Component props.
  * @returns {(Participant|undefined)}
  */
 function getActiveParticipant(props) {
@@ -118,10 +121,11 @@ function getActiveParticipant(props) {
 
 /**
  * Returns participant corresponding to video stream.
- * @param {MediaStream} stream
- * @param {(JitsiLocalTrack|JitsiRemoteTrack)[]} tracks
- * @param {Object} participants
- * @returns {(Object|undefined)}
+ *
+ * @param {MediaStream} stream - MediaStream.
+ * @param {(JitsiLocalTrack|JitsiRemoteTrack)[]} tracks - List of all tracks.
+ * @param {Participant[]} participants - List of all participants.
+ * @returns {(Participant|undefined)}
  */
 function getParticipantByVideoStream(stream, tracks, participants) {
     if (!stream) {
@@ -141,8 +145,9 @@ function getParticipantByVideoStream(stream, tracks, participants) {
 
 /**
  * Returns video stream for a specified participant.
- * @param {Participant} participant
- * @param {(JitsiLocalTrack|JitsiRemoteTrack)[]} tracks
+ *
+ * @param {Participant} participant - Participant object.
+ * @param {(JitsiLocalTrack|JitsiRemoteTrack)[]} tracks - List of all tracks.
  * @returns {(JitsiLocalTrack|JitsiRemoteTrack|undefined)}
  */
 function getVideoTrack(participant, tracks) {
@@ -156,7 +161,8 @@ function getVideoTrack(participant, tracks) {
 
 /**
  * Maps parts Redux state to Component's props.
- * @param {Object} state
+ *
+ * @param {Object} state - Redux state.
  * @returns {{
  *      tracks: (JitsiLocalTrack|JitsiRemoteTrack)[],
  *      participants: Participant[]

--- a/features/largeVideo/components/native/LargeVideoContainer.js
+++ b/features/largeVideo/components/native/LargeVideoContainer.js
@@ -9,6 +9,7 @@ import styles from './styles/Styles';
 export class LargeVideoContainer extends Component {
     /**
      * React component render method.
+     * 
      * @inheritdoc
      * @returns {XML}
      */

--- a/features/largeVideo/components/native/LargeVideoContainer.js
+++ b/features/largeVideo/components/native/LargeVideoContainer.js
@@ -7,6 +7,11 @@ import styles from './styles/Styles';
  * The native container rendering the person "on stage".
  */
 export class LargeVideoContainer extends Component {
+    /**
+     * React component render method.
+     * @inheritdoc
+     * @returns {XML}
+     */
     render() {
         return (
           <View style = { styles.largeVideo }>{ this.props.children }</View>
@@ -15,5 +20,5 @@ export class LargeVideoContainer extends Component {
 }
 
 LargeVideoContainer.propTypes = {
-    children: React.PropTypes.element
+    children: React.PropTypes.node
 };

--- a/features/largeVideo/components/web/LargeVideoContainer.js
+++ b/features/largeVideo/components/web/LargeVideoContainer.js
@@ -4,6 +4,11 @@ import React, { Component } from 'react';
  * The web container rendering the person "on stage".
  */
 export class LargeVideoContainer extends Component {
+    /**
+     * Implements React Component's render method.
+     * @inheritdoc
+     * @returns {XML}
+     */
     render() {
         return (
           <div>{this.props.children}</div>
@@ -11,6 +16,9 @@ export class LargeVideoContainer extends Component {
     }
 }
 
+/**
+ * Prop types for component.
+ */
 LargeVideoContainer.propTypes = {
-    children: React.PropTypes.element
+    children: React.PropTypes.node
 };

--- a/features/largeVideo/components/web/LargeVideoContainer.js
+++ b/features/largeVideo/components/web/LargeVideoContainer.js
@@ -6,6 +6,7 @@ import React, { Component } from 'react';
 export class LargeVideoContainer extends Component {
     /**
      * Implements React Component's render method.
+     * 
      * @inheritdoc
      * @returns {XML}
      */

--- a/features/toolbar/actions.js
+++ b/features/toolbar/actions.js
@@ -7,13 +7,27 @@ import {
 } from './actionTypes';
 import './reducer';
 
+/**
+ * Camera facing modes.
+ * @enum {string}
+ */
 const CAMERA_FACING_MODE = {
     ENVIRONMENT: 'environment',
     USER: 'user'
 };
 
 /**
+ * Media types.
+ * @enum {string}
+ */
+const MEDIA_TYPE = {
+    VIDEO: 'video',
+    AUDIO: 'audio'
+};
+
+/**
  * Leaves the conference and closes the connection.
+ * @returns {Function}
  */
 export function hangup() {
     return (dispatch, getState) => {
@@ -33,13 +47,15 @@ export function hangup() {
 
 /**
  * Toggles the mute state of the local audio track(s).
+ * @returns {Function}
  */
 export function toggleAudio() {
-    return toggleMedia('audio');
+    return toggleMedia(MEDIA_TYPE.AUDIO);
 }
 
 /**
  * Toggles the camera between front and rear (user and environment).
+ * @returns {Function}
  */
 export function toggleCameraFacingMode() {
     return (dispatch, getState) => {
@@ -51,7 +67,7 @@ export function toggleCameraFacingMode() {
 
         return dispatch(
                 createLocalTracks({
-                    devices: ['video'],
+                    devices: [ MEDIA_TYPE.VIDEO ],
                     facingMode: cameraFacingMode
                 })
             )
@@ -66,6 +82,8 @@ export function toggleCameraFacingMode() {
 
 /**
  * Toggles the mute state of the local tracks with the given media type.
+ * @param {MEDIA_TYPE} media
+ * @returns {Function}
  */
 function toggleMedia(media) {
     return (dispatch, getState) => {
@@ -84,7 +102,7 @@ function toggleMedia(media) {
         }
 
         dispatch({
-            type: media === 'video'
+            type: media === MEDIA_TYPE.VIDEO
                 ? TOGGLE_VIDEO_MUTED_STATE
                 : TOGGLE_AUDIO_MUTED_STATE
         });
@@ -93,7 +111,8 @@ function toggleMedia(media) {
 
 /**
  * Toggles the mute state of the local video track(s).
+ * @returns {Function}
  */
 export function toggleVideo() {
-    return toggleMedia('video');
+    return toggleMedia(MEDIA_TYPE.VIDEO);
 }

--- a/features/toolbar/actions.js
+++ b/features/toolbar/actions.js
@@ -27,6 +27,7 @@ const MEDIA_TYPE = {
 
 /**
  * Leaves the conference and closes the connection.
+ *
  * @returns {Function}
  */
 export function hangup() {
@@ -47,6 +48,7 @@ export function hangup() {
 
 /**
  * Toggles the mute state of the local audio track(s).
+ *
  * @returns {Function}
  */
 export function toggleAudio() {
@@ -55,6 +57,7 @@ export function toggleAudio() {
 
 /**
  * Toggles the camera between front and rear (user and environment).
+ *
  * @returns {Function}
  */
 export function toggleCameraFacingMode() {
@@ -82,7 +85,8 @@ export function toggleCameraFacingMode() {
 
 /**
  * Toggles the mute state of the local tracks with the given media type.
- * @param {MEDIA_TYPE} media
+ *
+ * @param {MEDIA_TYPE} media - Type of media device to toggle ('audio'/'video').
  * @returns {Function}
  */
 function toggleMedia(media) {
@@ -111,6 +115,7 @@ function toggleMedia(media) {
 
 /**
  * Toggles the mute state of the local video track(s).
+ *
  * @returns {Function}
  */
 export function toggleVideo() {

--- a/features/toolbar/components/Toolbar.js
+++ b/features/toolbar/components/Toolbar.js
@@ -3,13 +3,22 @@ import { connect } from 'react-redux';
 
 import { navigate } from '../../base/navigation';
 
-import { hangup, toggleAudio, toggleCameraFacingMode } from '../';
+import {
+    hangup,
+    toggleAudio,
+    toggleCameraFacingMode
+} from '../';
 import { ToolbarContainer } from './_';
 
 /**
  * The conference call toolbar.
  */
 class Toolbar extends Component {
+    /**
+     * Implements React Component's render method.
+     * @inheritdoc
+     * @returns {XML}
+     */
     render() {
         return (
             <ToolbarContainer
@@ -25,6 +34,9 @@ class Toolbar extends Component {
 
 /**
  * Maps the audioMuted and videoMuted properties to component props.
+ *
+ * @param {Object} state
+ * @returns {{ audioMuted: boolean, videoMuted: boolean }}
  */
 const mapStateToProps = state => {
     const stateFeaturesToolbar = state['features/toolbar'];
@@ -37,6 +49,12 @@ const mapStateToProps = state => {
 /**
  * Maps the onAudioMute, onHangup and onCameraChange actions to component
  * props.
+ * @param {Function} dispatch
+ * @returns {{
+ *      onAudioMute: Function,
+ *      onHangup: Function,
+ *      onCameraChange: Function
+ *  }}
  */
 const mapDispatchToProps = dispatch => {
     return {
@@ -56,6 +74,9 @@ const mapDispatchToProps = dispatch => {
     };
 };
 
+/**
+ * Prop types for component.
+ */
 Toolbar.propTypes = {
     onAudioMute: React.PropTypes.func,
     onHangup: React.PropTypes.func,

--- a/features/toolbar/components/Toolbar.js
+++ b/features/toolbar/components/Toolbar.js
@@ -16,6 +16,7 @@ import { ToolbarContainer } from './_';
 class Toolbar extends Component {
     /**
      * Implements React Component's render method.
+     *
      * @inheritdoc
      * @returns {XML}
      */
@@ -35,7 +36,7 @@ class Toolbar extends Component {
 /**
  * Maps the audioMuted and videoMuted properties to component props.
  *
- * @param {Object} state
+ * @param {Object} state - Redux state.
  * @returns {{ audioMuted: boolean, videoMuted: boolean }}
  */
 const mapStateToProps = state => {
@@ -49,7 +50,8 @@ const mapStateToProps = state => {
 /**
  * Maps the onAudioMute, onHangup and onCameraChange actions to component
  * props.
- * @param {Function} dispatch
+ *
+ * @param {Function} dispatch - Redux dispatch function.
  * @returns {{
  *      onAudioMute: Function,
  *      onHangup: Function,

--- a/features/toolbar/components/native/ToolbarContainer.js
+++ b/features/toolbar/components/native/ToolbarContainer.js
@@ -1,5 +1,8 @@
 import React, { Component } from 'react';
-import { Text, TouchableHighlight, View } from 'react-native';
+import {
+    TouchableHighlight,
+    View
+} from 'react-native';
 import Icon from 'react-native-vector-icons/FontAwesome';
 
 import { ColorPalette } from '../../../base/styles';
@@ -10,6 +13,11 @@ import styles from './styles/Styles';
  * The native container rendering the in call main buttons.
  */
 export class ToolbarContainer extends Component {
+    /**
+     * Implements React Component's render method.
+     * @inheritdoc
+     * @returns {XML}
+     */
     render() {
         var underlayColor = ColorPalette.buttonUnderlay;
         var micButtonStyle;
@@ -53,6 +61,9 @@ export class ToolbarContainer extends Component {
     }
 }
 
+/**
+ * Component's prop types.
+ */
 ToolbarContainer.propTypes = {
     onAudioMute: React.PropTypes.func,
     onHangup: React.PropTypes.func,

--- a/features/toolbar/components/native/ToolbarContainer.js
+++ b/features/toolbar/components/native/ToolbarContainer.js
@@ -15,6 +15,7 @@ import styles from './styles/Styles';
 export class ToolbarContainer extends Component {
     /**
      * Implements React Component's render method.
+     * 
      * @inheritdoc
      * @returns {XML}
      */

--- a/features/toolbar/components/web/ToolbarContainer.js
+++ b/features/toolbar/components/web/ToolbarContainer.js
@@ -5,7 +5,15 @@ import { ColorPalette } from '../../../base/styles';
 
 import styles from './styles/Styles';
 
+/**
+ * The web container rendering the toolbar.
+ */
 export class ToolbarContainer extends Component {
+    /**
+     * Implements React Component's render method.
+     * @inheritdoc
+     * @returns {XML}
+     */
     render() {
         var underlayColor = ColorPalette.buttonUnderlay;
         var micButtonStyle;
@@ -47,6 +55,9 @@ export class ToolbarContainer extends Component {
     }
 }
 
+/**
+ * Prop types for component.
+ */
 ToolbarContainer.propTypes = {
     onAudioMute: React.PropTypes.func,
     onHangup: React.PropTypes.func,

--- a/features/toolbar/components/web/ToolbarContainer.js
+++ b/features/toolbar/components/web/ToolbarContainer.js
@@ -11,6 +11,7 @@ import styles from './styles/Styles';
 export class ToolbarContainer extends Component {
     /**
      * Implements React Component's render method.
+     * 
      * @inheritdoc
      * @returns {XML}
      */

--- a/features/welcome/actions.js
+++ b/features/welcome/actions.js
@@ -29,6 +29,8 @@ const JitsiTrackEvents = JitsiMeetJS.events.track;
 
 /**
  * Create an action for when the signaling connection has been established.
+ * @param {JitsiConference} conference
+ * @returns {Function}
  */
 export function conferenceInitialized(conference) {
     return dispatch => {
@@ -71,6 +73,8 @@ export function conferenceInitialized(conference) {
 /**
  * Attach any pre-existing local media to the conference once the
  * conference has been joined.
+ * @param {JitsiConference} conference
+ * @returns {Function}
  */
 export function conferenceJoined(conference) {
     return (dispatch, getState) => {
@@ -90,6 +94,8 @@ export function conferenceJoined(conference) {
 
 /**
  * Create an action for when the signaling connection has been lost.
+ * @param {string} message
+ * @returns {{type: JITSI_CLIENT_DISCONNECTED, message: string}}
  */
 export function connectionDisconnected(message) {
     return {
@@ -100,6 +106,8 @@ export function connectionDisconnected(message) {
 
 /**
  * Create an action for when the signaling connection could not be created.
+ * @param {string} error
+ * @returns {{type: JITSI_CLIENT_ERROR, error: string}}
  */
 export function connectionError(error) {
     return {
@@ -110,6 +118,9 @@ export function connectionError(error) {
 
 /**
  * Create an action for when the signaling connection has been established.
+ * @param {string} id - the ID of the local endpoint/participant/peer (within
+ *      the context of the established connection)
+ * @returns {{type: JITSI_CLIENT_CONNECTED, id: string}}
  */
 export function connectionEstablished(id) {
     return {
@@ -120,6 +131,9 @@ export function connectionEstablished(id) {
 
 /**
  * Configure a newly created connection, binding its events to actions.
+ * @param {JitsiConnection} connection
+ * @param {string} room - conference room name
+ * @returns {Function}
  */
 export function connectionInitialized(connection, room) {
     return dispatch => {
@@ -155,6 +169,9 @@ export function connectionInitialized(connection, room) {
 /**
  * Initialize the JitsiMeetJS library, start local media, and then join
  * the named conference.
+ * @param {Object} config
+ * @param {string} room - conference room name
+ * @returns {Function}
  */
 export function init(config, room) {
     return dispatch => {
@@ -181,6 +198,8 @@ export function init(config, room) {
 
 /**
  * Create an action for when the JitsiMeetJS library could not be initialized.
+ * @param {Object} error
+ * @returns {{type: RTC_ERROR, error: Object}}
  */
 export function rtcError(error) {
     return {

--- a/features/welcome/actions.js
+++ b/features/welcome/actions.js
@@ -29,7 +29,8 @@ const JitsiTrackEvents = JitsiMeetJS.events.track;
 
 /**
  * Create an action for when the signaling connection has been established.
- * @param {JitsiConference} conference
+ *
+ * @param {JitsiConference} conference - Conference instance.
  * @returns {Function}
  */
 export function conferenceInitialized(conference) {
@@ -73,7 +74,8 @@ export function conferenceInitialized(conference) {
 /**
  * Attach any pre-existing local media to the conference once the
  * conference has been joined.
- * @param {JitsiConference} conference
+ *
+ * @param {JitsiConference} conference - Conference instance.
  * @returns {Function}
  */
 export function conferenceJoined(conference) {
@@ -94,7 +96,8 @@ export function conferenceJoined(conference) {
 
 /**
  * Create an action for when the signaling connection has been lost.
- * @param {string} message
+ *
+ * @param {string} message - Error message.
  * @returns {{type: JITSI_CLIENT_DISCONNECTED, message: string}}
  */
 export function connectionDisconnected(message) {
@@ -106,7 +109,8 @@ export function connectionDisconnected(message) {
 
 /**
  * Create an action for when the signaling connection could not be created.
- * @param {string} error
+ *
+ * @param {string} error - Error message.
  * @returns {{type: JITSI_CLIENT_ERROR, error: string}}
  */
 export function connectionError(error) {
@@ -118,8 +122,9 @@ export function connectionError(error) {
 
 /**
  * Create an action for when the signaling connection has been established.
- * @param {string} id - the ID of the local endpoint/participant/peer (within
- *      the context of the established connection)
+ *
+ * @param {string} id - The ID of the local endpoint/participant/peer (within
+ *      the context of the established connection).
  * @returns {{type: JITSI_CLIENT_CONNECTED, id: string}}
  */
 export function connectionEstablished(id) {
@@ -131,8 +136,9 @@ export function connectionEstablished(id) {
 
 /**
  * Configure a newly created connection, binding its events to actions.
- * @param {JitsiConnection} connection
- * @param {string} room - conference room name
+ *
+ * @param {JitsiConnection} connection - Connection instance.
+ * @param {string} room - Conference room name.
  * @returns {Function}
  */
 export function connectionInitialized(connection, room) {
@@ -169,8 +175,9 @@ export function connectionInitialized(connection, room) {
 /**
  * Initialize the JitsiMeetJS library, start local media, and then join
  * the named conference.
- * @param {Object} config
- * @param {string} room - conference room name
+ *
+ * @param {Object} config - Configuration object.
+ * @param {string} room - Conference room name.
  * @returns {Function}
  */
 export function init(config, room) {
@@ -198,7 +205,8 @@ export function init(config, room) {
 
 /**
  * Create an action for when the JitsiMeetJS library could not be initialized.
- * @param {Object} error
+ *
+ * @param {Object} error - Generic Error.
  * @returns {{type: RTC_ERROR, error: Object}}
  */
 export function rtcError(error) {

--- a/features/welcome/components/WelcomePage.js
+++ b/features/welcome/components/WelcomePage.js
@@ -12,6 +12,9 @@ class WelcomePage extends Component {
     /**
      * Render a WelcomePageContainer, which will show the room name
      * prompt appropriate for mobile or web.
+     *
+     * @inheritdoc
+     * @returns {XML}
      */
     render() {
         return (
@@ -26,6 +29,8 @@ class WelcomePage extends Component {
 
 /**
  * Maps the state room property to component props.
+ * @param {Object} state
+ * @returns {{ room: string }}
  */
 const mapStateToProps = state => {
     return {
@@ -35,6 +40,8 @@ const mapStateToProps = state => {
 
 /**
  * Maps the onJoin action.
+ * @param {Function} dispatch
+ * @returns {{ onJoin: Function }}
  */
 const mapDispatchToProps = (dispatch) => {
     return {
@@ -48,6 +55,9 @@ const mapDispatchToProps = (dispatch) => {
     };
 };
 
+/**
+ * Prop types for component.
+ */
 WelcomePage.propTypes = {
     onJoin: React.PropTypes.func,
     room: React.PropTypes.string,

--- a/features/welcome/components/WelcomePage.js
+++ b/features/welcome/components/WelcomePage.js
@@ -29,7 +29,8 @@ class WelcomePage extends Component {
 
 /**
  * Maps the state room property to component props.
- * @param {Object} state
+ *
+ * @param {Object} state - Redux state.
  * @returns {{ room: string }}
  */
 const mapStateToProps = state => {
@@ -40,7 +41,8 @@ const mapStateToProps = state => {
 
 /**
  * Maps the onJoin action.
- * @param {Function} dispatch
+ *
+ * @param {Function} dispatch - Redux dispatch function.
  * @returns {{ onJoin: Function }}
  */
 const mapDispatchToProps = (dispatch) => {

--- a/features/welcome/components/native/WelcomePageContainer.js
+++ b/features/welcome/components/native/WelcomePageContainer.js
@@ -10,6 +10,7 @@ export class WelcomePageContainer extends React.Component {
     /**
      * Render the WelcomePageContainer to show a prompt for
      * entering a room name.
+     * 
      * @inheritdoc
      * @returns {XML}
      */

--- a/features/welcome/components/native/WelcomePageContainer.js
+++ b/features/welcome/components/native/WelcomePageContainer.js
@@ -10,6 +10,8 @@ export class WelcomePageContainer extends React.Component {
     /**
      * Render the WelcomePageContainer to show a prompt for
      * entering a room name.
+     * @inheritdoc
+     * @returns {XML}
      */
     render() {
         return (

--- a/features/welcome/components/web/WelcomePageContainer.js
+++ b/features/welcome/components/web/WelcomePageContainer.js
@@ -10,9 +10,11 @@ export class WelcomePageContainer extends Component {
     /**
      * Initialize the WelcomePageContainer, including the initial
      * state of the room name input.
+     * @constructor
+     * @param {Object} props
      */
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
 
         this.state = {
             roomName: ''
@@ -30,6 +32,8 @@ export class WelcomePageContainer extends Component {
     /**
      * Render the WelcomePageContainer to show a prompt for
      * entering a room name.
+     * @inhertidoc
+     * @returns {XML}
      */
     render() {
         return (

--- a/features/welcome/components/web/WelcomePageContainer.js
+++ b/features/welcome/components/web/WelcomePageContainer.js
@@ -6,12 +6,11 @@ import styles from './styles/Styles';
  * The web container rendering the welcome page.
  */
 export class WelcomePageContainer extends Component {
-
     /**
      * Initialize the WelcomePageContainer, including the initial
      * state of the room name input.
-     * @constructor
-     * @param {Object} props
+     *
+     * @param {Object} props - Component properties.
      */
     constructor(props) {
         super(props);
@@ -32,7 +31,8 @@ export class WelcomePageContainer extends Component {
     /**
      * Render the WelcomePageContainer to show a prompt for
      * entering a room name.
-     * @inhertidoc
+     *
+     * @inheritdoc
      * @returns {XML}
      */
     render() {

--- a/index.native.js
+++ b/index.native.js
@@ -13,8 +13,9 @@ import { Conference } from './features/conference';
 import { init, styles, WelcomePage } from './features/welcome';
 
 /**
- * This router middleware is used to abstract navigation
- * inside the app for both native and web.
+ * This router middleware is used to abstract navigation inside the app for both
+ * native and web.
+ *
  * @param {Store} store - Redux store.
  * @returns {Object}
  */
@@ -49,8 +50,8 @@ class Root extends Component {
     /**
      * Initializes a new Root instance.
      *
-     * @param {Object} props - the read-only properties with which the new
-     * instance is to be initialized
+     * @param {Object} props - The read-only properties with which the new
+     * instance is to be initialized.
      */
     constructor(props) {
         super(props);
@@ -61,6 +62,7 @@ class Root extends Component {
 
     /**
      * Implements React Component's render method.
+     *
      * @inheritdoc
      * @returns {XML} - JSX markup.
      */
@@ -82,12 +84,12 @@ class Root extends Component {
     /**
      * Renders the scene identified by a specific route in a specific Navigator.
      *
-     * @param {Object} route - the route which identifies the scene to be
+     * @param {Object} route - The route which identifies the scene to be
      * rendered in the specified navigator. In the fashion of NavigatorIOS, the
      * specified route is expected to define a value for its component property
      * which is the type of React component to be rendered.
-     * @param {Navigator} navigator - the Navigator in which the scene
-     * identified by the specified route is to be rendered
+     * @param {Navigator} navigator - The Navigator in which the scene
+     * identified by the specified route is to be rendered.
      * @private
      * @returns {ReactElement}
      */

--- a/index.native.js
+++ b/index.native.js
@@ -13,8 +13,10 @@ import { Conference } from './features/conference';
 import { init, styles, WelcomePage } from './features/welcome';
 
 /**
- * This router middleware is used to abstract navigation inside the app for both
- * native and web.
+ * This router middleware is used to abstract navigation
+ * inside the app for both native and web.
+ * @param {Store} store - Redux store.
+ * @returns {Object}
  */
 const router = store => next => action => {
     if (action.type === APP_NAVIGATE) {
@@ -39,11 +41,15 @@ const router = store => next => action => {
 const reducer = ReducerRegistry.combineReducers();
 const store = createStore(reducer, applyMiddleware(Thunk, router));
 
+/**
+ * App root component.
+ * @extends Component
+ */
 class Root extends Component {
     /**
      * Initializes a new Root instance.
      *
-     * @param {object} props - the read-only properties with which the new
+     * @param {Object} props - the read-only properties with which the new
      * instance is to be initialized
      */
     constructor(props) {
@@ -53,6 +59,11 @@ class Root extends Component {
         this._navigatorRenderScene = this._navigatorRenderScene.bind(this);
     }
 
+    /**
+     * Implements React Component's render method.
+     * @inheritdoc
+     * @returns {XML} - JSX markup.
+     */
     render() {
         return (
             <Provider store={store}>
@@ -71,13 +82,14 @@ class Root extends Component {
     /**
      * Renders the scene identified by a specific route in a specific Navigator.
      *
-     * @param {object} route - the route which identifies the scene to be
+     * @param {Object} route - the route which identifies the scene to be
      * rendered in the specified navigator. In the fashion of NavigatorIOS, the
      * specified route is expected to define a value for its component property
      * which is the type of React component to be rendered.
      * @param {Navigator} navigator - the Navigator in which the scene
      * identified by the specified route is to be rendered
      * @private
+     * @returns {ReactElement}
      */
     _navigatorRenderScene(route, navigator) {
         // We started with NavigatorIOS and then switched to Navigator in order

--- a/index.web.js
+++ b/index.web.js
@@ -18,8 +18,9 @@ import { Conference } from './features/conference';
 import { init, WelcomePage } from './features/welcome';
 
 /**
- * This router middleware is used to abstract navigation
- * inside the app for both native and web.
+ * This router middleware is used to abstract navigation inside the app for both
+ * native and web.
+ *
  * @param {Store} store - Redux store.
  * @returns {Object}
  */

--- a/index.web.js
+++ b/index.web.js
@@ -18,8 +18,10 @@ import { Conference } from './features/conference';
 import { init, WelcomePage } from './features/welcome';
 
 /**
- * This router middleware is used to abstract navigation inside the app for both
- * native and web.
+ * This router middleware is used to abstract navigation
+ * inside the app for both native and web.
+ * @param {Store} store - Redux store.
+ * @returns {Object}
  */
 const router = store => next => action => {
     if (action.type === APP_NAVIGATE) {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-preset-stage-1": "^6.5.0",
     "browserify": "11.1.x",
     "eslint": "^2.13.1",
+    "eslint-plugin-jsdoc": "^2.3.1",
     "eslint-plugin-react": "^5.2.2",
     "exorcist": "^0.4.0",
     "html-webpack-template": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build:web": "mkdir -p dist/; cp -r static/* dist/; webpack",
     "clean": "rm -rf dist",
-    "eslint": "node_modules/eslint/bin/eslint.js features/**/*.js index.*.js",
+    "eslint": "node_modules/eslint/bin/eslint.js \"features/**/*.js\" \"index.*.js\"",
     "start:android": "npm run clean; react-native run-android",
     "start:ios": "npm run clean; react-native run-ios",
     "start:web": "webpack-dev-server --inline --hot --colors --port 5000 --https --history-api-fallback --open"


### PR DESCRIPTION
Adds three new eslint rule groups:
- enforces jsdoc comments on methods, functions and classes with require-jsdoc rule
- valid-jsdoc rule that forces valid jsdoc comments
- additional styling/formatting rules for jsdoc comments with "eslint-jsdoc-plugin"
