### PR TITLE
Correctly dispose local tracks when hanging up

### DIFF
--- a/features/base/conference/actions.js
+++ b/features/base/conference/actions.js
@@ -56,7 +56,13 @@ export function conferenceInitialized(conference) {
         conference.on(JitsiConferenceEvents.TRACK_MUTE_CHANGED,
             track => dispatch(trackMuteChanged(track)));
         conference.on(JitsiConferenceEvents.TRACK_REMOVED,
-            track => dispatch(trackRemoved(track)));
+            track => {
+                if (!track || track.isLocal()) {
+                    return;
+                }
+
+                dispatch(trackRemoved(track));
+            });
 
         conference.on(JitsiConferenceEvents.USER_JOINED,
             (id, user) => dispatch(remoteParticipantJoined(id, {

--- a/features/base/participants/actions.js
+++ b/features/base/participants/actions.js
@@ -92,28 +92,6 @@ export function localParticipantJoined(id, participant = {}) {
 }
 
 /**
- * Action to remove a local participant.
- *
- * @returns {Function}
- */
-export function localParticipantLeft() {
-    return (dispatch, getState) => {
-        let localParticipant = getState()['features/base/participants']
-            .find(p => p.local);
-
-        if (localParticipant) {
-            return dispatch({
-                type: PARTICIPANT_LEFT,
-                participant: {
-                    id: localParticipant.id,
-                    local: true
-                }
-            });
-        }
-    };
-}
-
-/**
  * Create an action for when the participant in conference is focused.
  *
  * @param {string|null} id - Participant id or null if no one is currently

--- a/features/base/participants/actions.js
+++ b/features/base/participants/actions.js
@@ -92,6 +92,28 @@ export function localParticipantJoined(id, participant = {}) {
 }
 
 /**
+ * Action to remove a local participant.
+ *
+ * @returns {Function}
+ */
+export function localParticipantLeft() {
+    return (dispatch, getState) => {
+        let localParticipant = getState()['features/base/participants']
+            .find(p => p.local);
+
+        if (localParticipant) {
+            return dispatch({
+                type: PARTICIPANT_LEFT,
+                participant: {
+                    id: localParticipant.id,
+                    local: true
+                }
+            });
+        }
+    };
+}
+
+/**
  * Create an action for when the participant in conference is focused.
  *
  * @param {string|null} id - Participant id or null if no one is currently

--- a/features/base/participants/index.js
+++ b/features/base/participants/index.js
@@ -1,2 +1,3 @@
 export * from './actions';
+export * from './actionTypes';
 export * from './constants';

--- a/features/base/participants/reducer.js
+++ b/features/base/participants/reducer.js
@@ -1,3 +1,4 @@
+import { CONFERENCE_LEFT } from '../conference';
 import { ReducerRegistry } from '../redux';
 
 import {
@@ -125,6 +126,12 @@ function participant(state, action) {
  */
 ReducerRegistry.register('features/base/participants', (state = [], action) => {
     switch (action.type) {
+    /**
+     * Remove local participant when conference is left.
+     */
+    case CONFERENCE_LEFT:
+        return state.filter(p => !p.local);
+
     case PARTICIPANT_JOINED:
         return [ ...state, participant(undefined, action) ];
 

--- a/features/base/participants/reducer.js
+++ b/features/base/participants/reducer.js
@@ -1,5 +1,3 @@
-import { CONFERENCE_LEFT } from '../conference';
-import { CONNECTION_DISCONNECTED } from '../connection';
 import { ReducerRegistry } from '../redux';
 
 import {
@@ -127,18 +125,6 @@ function participant(state, action) {
  */
 ReducerRegistry.register('features/base/participants', (state = [], action) => {
     switch (action.type) {
-    /**
-     * Remove local participants when connection is disconnected.
-     */
-    case CONNECTION_DISCONNECTED:
-        return state.filter(p => !p.local);
-
-    /**
-     * Remove remote participants when conference is left.
-     */
-    case CONFERENCE_LEFT:
-        return state.filter(p => p.local);
-
     case PARTICIPANT_JOINED:
         return [ ...state, participant(undefined, action) ];
 

--- a/features/base/tracks/actions.js
+++ b/features/base/tracks/actions.js
@@ -138,8 +138,8 @@ export function createLocalTracks(options) {
  */
 export function destroyLocalTracks() {
     return (dispatch, getState) => {
-        return disposeAndRemoveTracks(
-            getState()['features/base/tracks'].filter(t => t.isLocal()));
+        return dispatch(disposeAndRemoveTracks(
+            getState()['features/base/tracks'].filter(t => t.isLocal())));
     };
 }
 

--- a/features/base/tracks/reducer.js
+++ b/features/base/tracks/reducer.js
@@ -13,17 +13,14 @@ import {
 ReducerRegistry.register('features/base/tracks', (state = [], action) => {
     switch (action.type) {
     /**
-     * Remove participant's tracks after/when participant leaves.
+     * Remove remote participant's tracks after/when participant leaves.
+     * TODO: this can be removed when
+     * https://github.com/jitsi/lib-jitsi-meet/pull/174 will be merged.
      */
     case PARTICIPANT_LEFT:
-        return (
-            state.filter(
-                track => action.participant.local
-                    ? !track.isLocal()
-                    : (track.isLocal()
-                        || track.getParticipantId() !== action.participant.id)
-            )
-        );
+        return state.filter(
+            track => track.isLocal() ||
+                track.getParticipantId() !== action.participant.id);
 
     case TRACK_ADDED:
         return [...state, action.track];

--- a/features/toolbar/actions.js
+++ b/features/toolbar/actions.js
@@ -1,8 +1,4 @@
-import { localParticipantLeft } from '../base/participants';
-import {
-    createLocalTracks,
-    destroyLocalTracks
-} from '../base/tracks';
+import { createLocalTracks } from '../base/tracks';
 
 import {
     CHANGE_CAMERA_FACING_MODE,
@@ -28,40 +24,6 @@ const MEDIA_TYPE = {
     VIDEO: 'video',
     AUDIO: 'audio'
 };
-
-/**
- * Leaves the conference and closes the connection.
- *
- * @returns {Function}
- */
-export function hangup() {
-    return (dispatch, getState) => {
-        const state = getState();
-        const conference = state['features/base/conference'];
-        const connection = state['features/base/connection'];
-
-        let promise = Promise.resolve();
-
-        if (conference) {
-            promise = promise
-                .then(() => conference.leave());
-        }
-
-        if (connection) {
-            promise = promise
-                .then(() => connection.disconnect());
-        }
-
-        // XXX Local tracks and local participant might exist without conference
-        // and connection initialized, so we need to explicitly clean them here.
-        // Furthermore, currently local tracks can be initialized before local
-        // participant is created, so we cannot hope that they will be destroyed
-        // when (and if) local participant leaves.
-        return promise
-            .then(() => dispatch(destroyLocalTracks()))
-            .then(() => dispatch(localParticipantLeft()));
-    };
-}
 
 /**
  * Toggles the mute state of the local audio track(s).

--- a/features/toolbar/components/Toolbar.js
+++ b/features/toolbar/components/Toolbar.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
+import { destroy } from '../../base/connection';
 import { navigate } from '../../base/navigation';
 
 import {
-    hangup,
     toggleAudio,
     toggleCameraFacingMode
 } from '../';
@@ -67,7 +67,7 @@ const mapDispatchToProps = dispatch => {
             dispatch(toggleCameraFacingMode());
         },
         onHangup: navigator => {
-            dispatch(hangup())
+            dispatch(destroy())
                 .then(() => dispatch(navigate({ screen: 'home', navigator })));
         }
     };


### PR DESCRIPTION
Do not remove local tracks on JitsiConferenceEvents.TRACK_REMOVED event, instead dispose and remove them separately in hangup() method.
Fix missing import of participant's actionTypes.
Signal local participant left after hanging the conference.
Remove un-necessary cases in participant's reducer.
