### PR TITLE
Define config as global var to prevent eslint error

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,3 +1,5 @@
+/* global config */
+
 let domain = 'meet.jit.si';
 
 module.exports = {


### PR DESCRIPTION
Defines "config" as global var in config.js to prevent eslint error
