### PR TITLE
Set root component color on iOS

### DIFF
--- a/features/base/styles/components/styles/ColorPalette.js
+++ b/features/base/styles/components/styles/ColorPalette.js
@@ -2,6 +2,7 @@
  * The application color palette.
  */
 export const ColorPalette = {
+    appBackground: '#111111',
     buttonUnderlay: '#495258',
     jitsiBlue: '#00ccff',
     jitsiRed: '#ff0000',

--- a/features/largeVideo/components/styles/Styles.js
+++ b/features/largeVideo/components/styles/Styles.js
@@ -1,9 +1,9 @@
-import { createStyleSheet } from '../../../base/styles';
+import { ColorPalette, createStyleSheet } from '../../../base/styles';
 
 export const styles = createStyleSheet({
     container: {
         alignSelf: 'stretch',
-        backgroundColor: 'black',
+        backgroundColor: ColorPalette.appBackground,
         bottom: 0,
         flex: 1,
         left: 0,

--- a/ios/JitsiMeetApp/AppDelegate.m
+++ b/ios/JitsiMeetApp/AppDelegate.m
@@ -47,7 +47,8 @@
                                                       moduleName:@"JitsiMeetApp"
                                                initialProperties:nil
                                                    launchOptions:launchOptions];
-  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+  // Set rootView.backgroundColor to #111111
+  rootView.backgroundColor = [[UIColor alloc] initWithRed:.07f green:.07f blue:.07f alpha:1];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [UIViewController new];


### PR DESCRIPTION
This fixes the flashes of white when rotating on iOS.

There is an equivalent change that needs to be made for Android, but I don't have things set up to test Android:

``` diff
--- a/android/app/src/main/java/com/jitsimeetapp/MainActivity.java
+++ b/android/app/src/main/java/com/jitsimeetapp/MainActivity.java
@@ -4,6 +4,7 @@ import com.facebook.react.ReactActivity;
 import com.oblador.vectoricons.VectorIconsPackage;
 import com.oney.WebRTCModule.WebRTCModulePackage;
 import com.facebook.react.ReactPackage;
+import com.facebook.react.ReactRootView;
 import com.facebook.react.shell.MainReactPackage;

 import java.util.Arrays;
@@ -12,6 +13,16 @@ import java.util.List;
 public class MainActivity extends ReactActivity {

     /**
+     * Returns the root component for the app.
+     */
+    @Override
+    protected ReactRootView createRootView() {
+        ReactRootView rootView = super.createRootView();
+        rootView.setBackgroundColor(0xFF111111);
+        return rootView;
+    }
+
+    /**
      * Returns the name of the main component registered from JavaScript.
      * This is used to schedule rendering of the component.
      */
```
