### PR TITLE
Added beta.meet.jit.si to list of exceptions to allow HTTP loads

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,20 +1,45 @@
 /* global config */
 
-let domain = 'meet.jit.si';
+// Override the default connection configuration. For legacy reasons, use
+// jitsi-meet's global variable config.
+let connection = (typeof config !== 'undefined' && config);
 
-module.exports = {
-    connection: (
-        // Override the default connection configuration. For legacy reasons,
-        // use jitsi-meet's global variable config.
-        (typeof config !== 'undefined' && config)
+if (!connection) { // Default connection configuration
+    let domain = 'beta.meet.jit.si';
 
-            || /* Default connection configuration */ {
-                bosh: 'https://' + domain + '/http-bind',
-                hosts: {
-                    domain,
-                    focus: 'focus.' + domain,
-                    muc: 'conference.' + domain
-                }
+    // FIXME The HTTPS scheme for the BOSH URL works with meet.jit.si on both
+    // mobile & Web. It also works with beta.meet.jit.si on Web. Unfortunately,
+    // it doesn't work with beta.meet.jit.si on mobile. Temporarily, use the
+    // HTTP scheme for the BOSH URL with beta.meet.jit.si on mobile.
+    let boshProtocol;
+    if (domain === 'beta.meet.jit.si') {
+        if (typeof window === 'object') {
+            let windowLocation = window.location;
+            if (windowLocation) {
+                // React Native doesn't have a window.location at the time of
+                // this writing, let alone a window.location.protocol.
+                boshProtocol = windowLocation.protocol;
             }
-    )
+        }
+        if (!boshProtocol) {
+            boshProtocol = 'http:';
+        }
+    }
+    // Default to the HTTPS scheme for the BOSH URL.
+    if (!boshProtocol) {
+        boshProtocol = 'https:';
+    }
+
+    connection = {
+        bosh: boshProtocol + '//' + domain + '/http-bind',
+        hosts: {
+            domain,
+            focus: 'focus.' + domain,
+            muc: 'conference.' + domain
+        }
+    };
+}
+
+export default {
+    connection
 };

--- a/ios/app/Info.plist
+++ b/ios/app/Info.plist
@@ -48,6 +48,11 @@
 				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 			</dict>
+			<key>beta.meet.jit.si</key>
+            <dict>
+                <key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+            </dict>
 		</dict>
 	</dict>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
Since iOS 9 and new XCode versions Apple does not allow connecting to non-HTTPS domains (http://www.neglectedpotential.com/2015/06/working-with-apples-application-transport-security/). In order to allow connecting to http://beta.meet.jit.si, I've added exception to Info.plist
