### PR TITLE
Introduced PARTICIPANT_ID_CHANGED action

### DIFF
--- a/features/base/conference/actions.js
+++ b/features/base/conference/actions.js
@@ -2,10 +2,10 @@ import JitsiMeetJS from '../lib-jitsi-meet';
 import {
     changeParticipantEmail,
     dominantSpeakerChanged,
+    participantJoined,
     participantLeft,
     participantRoleChanged,
-    participantVideoTypeChanged,
-    remoteParticipantJoined
+    participantVideoTypeChanged
 } from '../participants';
 import {
     trackAdded,
@@ -158,9 +158,10 @@ function _setupConferenceListeners(conference) {
             });
 
         conference.on(JitsiConferenceEvents.USER_JOINED,
-            (id, user) => dispatch(remoteParticipantJoined(id, {
-                role: user.getRole(),
-                displayName: user.getDisplayName()
+            (id, user) => dispatch(participantJoined({
+                id,
+                name: user.getDisplayName(),
+                role: user.getRole()
             })));
         conference.on(JitsiConferenceEvents.USER_LEFT,
             id => dispatch(participantLeft(id)));

--- a/features/base/participants/actionTypes.js
+++ b/features/base/participants/actionTypes.js
@@ -1,5 +1,69 @@
+/**
+ * Create an action for when dominant speaker changes.
+ *
+ * {
+ *      type: DOMINANT_SPEAKER_CHANGED,
+ *      participant: {
+ *          id: string
+ *      }
+ * }
+ */
 export const DOMINANT_SPEAKER_CHANGED = 'DOMINANT_SPEAKER_CHANGED';
+
+/**
+ * Action to signal that ID of participant has changed. This happens when
+ * local participant joins a new conference or quits one.
+ *
+ * {
+ *      type: PARTICIPANT_ID_CHANGED,
+ *      participant: {
+ *          newId: string,
+ *          previousId: string
+ *      }
+ * }
+ */
+export const PARTICIPANT_ID_CHANGED = 'PARTICIPANT_ID_CHANGED';
+
+/**
+ * Action to signal that a participant has joined.
+ *
+ * {
+ *      type: PARTICIPANT_JOINED,
+ *      participant: Participant
+ * }
+ */
 export const PARTICIPANT_JOINED = 'PARTICIPANT_JOINED';
+
+/**
+ * Action to handle case when participant lefts.
+ *
+ * {
+ *      type: PARTICIPANT_LEFT,
+ *      participant: {
+ *          id: string
+ *      }
+ * }
+ */
 export const PARTICIPANT_LEFT = 'PARTICIPANT_LEFT';
+
+/**
+ * Create an action for when the participant in conference is pinned.
+ *
+ * {
+ *      type: PARTICIPANT_PINNED,
+ *      participant: {
+ *          id: string
+ *      }
+ * }
+ */
 export const PARTICIPANT_PINNED = 'PARTICIPANT_PINNED';
+
+/**
+ * Action to handle case when info about participant changes.
+ *
+ * {
+ *      type: PARTICIPANT_UPDATED,
+ *      participant: Participant
+ * }
+ */
 export const PARTICIPANT_UPDATED = 'PARTICIPANT_UPDATED';

--- a/features/base/participants/middleware.js
+++ b/features/base/participants/middleware.js
@@ -1,0 +1,30 @@
+import {
+    CONFERENCE_JOINED,
+    CONFERENCE_LEFT
+} from '../conference';
+import { MiddlewareRegistry } from '../redux';
+
+import { localParticipantIdChanged } from './actions';
+import { LOCAL_PARTICIPANT_DEFAULT_ID } from './constants';
+
+/**
+ * Middleware that captures CONFERENCE_JOINED and CONFERENCE_LEFT actions
+ * and updates respectively ID of local participant.
+ *
+ * @param {Store} store - Redux store.
+ * @returns {Function}
+ */
+MiddlewareRegistry.register(store => next => action => {
+    switch (action.type) {
+    case CONFERENCE_JOINED:
+        let id = action.conference.jitsiConference.myUserId();
+        store.dispatch(localParticipantIdChanged(id));
+        break;
+
+    case CONFERENCE_LEFT:
+        store.dispatch(localParticipantIdChanged(LOCAL_PARTICIPANT_DEFAULT_ID));
+        break;
+    }
+
+    return next(action);
+});

--- a/features/base/participants/reducer.js
+++ b/features/base/participants/reducer.js
@@ -1,13 +1,10 @@
 /* global MD5 */
 
-import {
-    CONFERENCE_JOINED,
-    CONFERENCE_LEFT
-} from '../conference';
 import { ReducerRegistry } from '../redux';
 
 import {
     DOMINANT_SPEAKER_CHANGED,
+    PARTICIPANT_ID_CHANGED,
     PARTICIPANT_JOINED,
     PARTICIPANT_LEFT,
     PARTICIPANT_PINNED,
@@ -58,12 +55,15 @@ const PARTICIPANT_PROPS_TO_OMIT_WHEN_UPDATE =
  */
 function participant(state, action) {
     switch (action.type) {
-    /**
-     * Sets participant id according to conference.
-     */
-    case CONFERENCE_JOINED:
-        if (state.local) {
-            let id = action.conference.jitsiConference.myUserId();
+    case DOMINANT_SPEAKER_CHANGED:
+        // Only one dominant speaker is allowed.
+        return Object.assign({}, state, {
+            speaking: state.id === action.participant.id
+        });
+
+    case PARTICIPANT_ID_CHANGED:
+        if (state.id === action.participant.previousId) {
+            let id = action.participant.newId;
 
             return {
                 ...state,
@@ -73,45 +73,27 @@ function participant(state, action) {
         }
         return state;
 
-    /**
-     * Cleans conference-specific properties of the local participant when
-     * conference is left.
-     */
-    case CONFERENCE_LEFT:
-        if (state.local) {
-            return {
-                ...state,
-                id: LOCAL_PARTICIPANT_DEFAULT_ID,
-                avatar: state.avatar ||
-                    _getAvatarURL(LOCAL_PARTICIPANT_DEFAULT_ID, state.email),
-                focused: false,
-                pinned: false,
-                role: PARTICIPANT_ROLE.NONE,
-                selected: false,
-                speaking: false
-            };
-        }
-        return state;
-
-    case DOMINANT_SPEAKER_CHANGED:
-        // Only one dominant speaker is allowed.
-        return Object.assign({}, state, {
-            speaking: state.id === action.participant.id
-        });
-
     case PARTICIPANT_JOINED:
+        let participant = action.participant;
+        let participantId = participant.id
+            || (participant.local && LOCAL_PARTICIPANT_DEFAULT_ID);
+        let participantAvatar = participant.avatar
+            || _getAvatarURL(participantId, participant.email);
+        // TODO: get these names from config/localized
+        let participantName = participant.name
+            || (participant.local ? 'me' : 'Fellow Jitster');
+
         return {
-            id: action.participant.id,
-            avatar: action.participant.avatar ||
-                _getAvatarURL(action.participant.id, action.participant.email),
-            email: action.participant.email,
-            local: action.participant.local || false,
-            name: action.participant.name,
-            pinned: action.participant.pinned || false,
-            role: action.participant.role || PARTICIPANT_ROLE.NONE,
-            speaking: action.participant.speaking || false,
+            avatar: participantAvatar,
+            email: participant.email,
+            id: participantId,
+            local: participant.local || false,
+            name: participantName,
+            pinned: participant.pinned || false,
+            role: participant.role || PARTICIPANT_ROLE.NONE,
+            speaking: participant.speaking || false,
             videoStarted: false,
-            videoType: action.participant.videoType || undefined
+            videoType: participant.videoType || undefined
         };
 
     case PARTICIPANT_PINNED:
@@ -164,9 +146,8 @@ ReducerRegistry.register('features/base/participants', (state = [], action) => {
     case PARTICIPANT_LEFT:
         return state.filter(p => p.id !== action.participant.id);
 
-    case CONFERENCE_JOINED:
-    case CONFERENCE_LEFT:
     case DOMINANT_SPEAKER_CHANGED:
+    case PARTICIPANT_ID_CHANGED:
     case PARTICIPANT_PINNED:
     case PARTICIPANT_UPDATED:
         return state.map(p => participant(p, action));

--- a/features/largeVideo/reducer.js
+++ b/features/largeVideo/reducer.js
@@ -1,8 +1,4 @@
-import {
-    CONFERENCE_JOINED,
-    CONFERENCE_LEFT
-} from '../base/conference';
-import { LOCAL_PARTICIPANT_DEFAULT_ID } from '../base/participants';
+import { PARTICIPANT_ID_CHANGED } from '../base/participants';
 import { ReducerRegistry } from '../base/redux';
 
 import { LARGE_VIDEO_PARTICIPANT_CHANGED } from './actionTypes';
@@ -20,26 +16,14 @@ ReducerRegistry.register(
         // already selected 'local' as participant on stage. So in this case we
         // must update ID of participant on stage to match ID in 'participants'
         // state to avoid additional changes in state and (re)renders.
-
-        // FIXME
-        // https://github.com/jitsi/jitsi-meet-react/pull/62/files#r73208289
-        case CONFERENCE_JOINED:
-            if (state.participantId === LOCAL_PARTICIPANT_DEFAULT_ID) {
-                let id = action.conference.jitsiConference.myUserId();
-
+        case PARTICIPANT_ID_CHANGED:
+            if (state.participantId === action.participant.previousId) {
                 return {
                     ...state,
-                    participantId: id
+                    participantId: action.participant.newId
                 };
             }
             return state;
-
-        // Reverse the effects of CONFERENCE_JOINED.
-        case CONFERENCE_LEFT:
-            return {
-                ...state,
-                participantId: LOCAL_PARTICIPANT_DEFAULT_ID
-            };
 
         case LARGE_VIDEO_PARTICIPANT_CHANGED:
             return {


### PR DESCRIPTION
This PR addresses @lyubomir's comment - https://github.com/jitsi/jitsi-meet-react/pull/62/files#r73208289.

Here we introduce new PARTICIPANT_ID_CHANGED action and dispatch it for local participant when CONFERENCE_JOINED or CONFERENCE_LEFT.
