### PR TITLE
Refactored pinParticipant() functionality to remove tight coupling

### DIFF
--- a/features/base/conference/middleware.js
+++ b/features/base/conference/middleware.js
@@ -1,3 +1,4 @@
+import { PARTICIPANT_PINNED } from '../participants';
 import { MiddlewareRegistry } from '../redux';
 import {
     TRACK_ADDED,
@@ -11,7 +12,8 @@ import {
 
 /**
  * This middleware intercepts TRACK_ADDED and TRACK_REMOVED actions to sync
- * conference's local tracks with local tracks in state.
+ * conference's local tracks with local tracks in state. Also captures
+ * PARTICIPANT_PINNED action to pin participant in conference.
  *
  * @param {Store} store - Redux store.
  * @returns {Function}
@@ -27,10 +29,40 @@ MiddlewareRegistry.register(store => next => action => {
                 .then(() => next(action));
         }
         break;
+
+    case PARTICIPANT_PINNED:
+        pinParticipant(store, action.participant.id);
+        break;
     }
 
     return next(action);
 });
+
+/**
+ * Pins remote participant in conference, ignores local participant.
+ *
+ * @param {Store} store - Redux store.
+ * @param {string|null} id - Participant id or null if no one is currently
+ * pinned.
+ * @returns {void}
+ */
+function pinParticipant(store, id) {
+    let state = store.getState();
+    let conference = state['features/base/conference'].jitsiConference;
+    let participants = state['features/base/participants'];
+    let participantById = participants.find(p => p.id === id);
+    let localParticipant = participants.find(p => p.local);
+
+    // This condition prevents signaling to pin local participant. Here is
+    // the logic: if we have ID, then we check if participant by that ID is
+    // local. If we don't have ID and thus no participant by ID, we check
+    // for local participant. If it's currently pinned, then this action
+    // will unpin him and that's why we won't signal here too.
+    if ((participantById && !participantById.local) ||
+        (!participantById && (!localParticipant || !localParticipant.pinned))) {
+        conference.pinParticipant(id);
+    }
+}
 
 /**
  * Syncs local tracks from state with local tracks in JitsiConference instance.

--- a/features/base/participants/actions.js
+++ b/features/base/participants/actions.js
@@ -125,6 +125,27 @@ export function participantLeft(id) {
 }
 
 /**
+ * Create an action for when the participant in conference is pinned.
+ *
+ * @param {string|null} id - Participant id or null if no one is currently
+ * pinned.
+ * @returns {{
+ *      type: PARTICIPANT_PINNED,
+ *      participant: {
+ *          id: string
+ *      }
+ * }}
+ */
+export function participantPinned(id) {
+    return {
+        type: PARTICIPANT_PINNED,
+        participant: {
+            id
+        }
+    };
+}
+
+/**
  * Action to handle case when participant's role changes.
  *
  * @param {string} id - Participant id.
@@ -189,40 +210,6 @@ export function participantVideoTypeChanged(id, videoType) {
             id,
             videoType
         }
-    };
-}
-
-/**
- * Create an action for when the participant in conference is pinned.
- *
- * @param {string|null} id - Participant id or null if no one is currently
- *     pinned.
- * @returns {Function}
- */
-export function pinParticipant(id) {
-    return (dispatch, getState) => {
-        let state = getState();
-        let conference = state['features/base/conference'].jitsiConference;
-        let participants = state['features/base/participants'];
-        let participant = participants.find(p => p.id === id);
-        let localParticipant = participants.find(p => p.local);
-
-        // This condition prevents signaling to pin local participant. Here is
-        // the logic: if we have ID, then we check if participant by that ID is
-        // local. If we don't have ID and thus no participant by ID, we check
-        // for local participant. If it's currently pinned, then this action
-        // will unpin him and that's why we won't signal here too.
-        if ((participant && !participant.local) ||
-            (!participant && (!localParticipant || !localParticipant.pinned))) {
-            conference.pinParticipant(id);
-        }
-
-        return dispatch({
-            type: PARTICIPANT_PINNED,
-            participant: {
-                id
-            }
-        });
     };
 }
 

--- a/features/filmStrip/components/VideoThumbnail.js
+++ b/features/filmStrip/components/VideoThumbnail.js
@@ -8,8 +8,8 @@ import {
 } from '../../base/media';
 import {
     PARTICIPANT_ROLE,
-    participantVideoStarted,
-    pinParticipant
+    participantPinned,
+    participantVideoStarted
 } from '../../base/participants';
 
 import {
@@ -64,7 +64,7 @@ class VideoThumbnail extends Component {
         let { dispatch, participant } = this.props;
 
         // TODO: this currently ignores interfaceConfig.filmStripOnly
-        dispatch(pinParticipant(
+        dispatch(participantPinned(
             participant.pinned
                 ? null
                 : participant.id));


### PR DESCRIPTION
Now PARTICIPANT_PINNED action is handled in conference's middleware.
