### PR TITLE
Temporary fix to prevent showing errors when data channels were not yet initialized

### DIFF
--- a/features/base/conference/functions.js
+++ b/features/base/conference/functions.js
@@ -44,6 +44,23 @@ export function isRoomValid(room) {
 }
 
 /**
+ * Handle exception received when trying to pin or select an endpoint in
+ * conference.
+ *
+ * @param {Error} error - Error.
+ * @returns {void}
+ */
+export function handleEndpointChangeError(error) {
+    // XXX DataChannels are initialized at some later point when conference has
+    // multiple participants, but code that pins or selects an endpoint might be
+    // executed before. So here we're swallowing a particular error.
+    // TODO this should be fixed in lib-jitsi-meet.
+    if (error.message !== 'Data channels support is disabled!') {
+        throw error;
+    }
+}
+
+/**
  * Remove a set of local tracks from a conference.
  *
  * NOTE The function is internal to this feature.

--- a/features/base/conference/middleware.js
+++ b/features/base/conference/middleware.js
@@ -10,6 +10,7 @@ import {
 
 import {
     _addLocalTracksToConference,
+    handleEndpointChangeError,
     _removeLocalTracksFromConference
 } from './functions';
 
@@ -71,14 +72,7 @@ function pinParticipant(store, id) {
         try {
             conference.pinParticipant(id);
         } catch (ex) {
-            // XXX DataChannels are initialized at some later point when
-            // conference has multiple participants, but this code might
-            // be executed before. So here we're swallowing a particular
-            // error.
-            // TODO this should be fixed in lib-jitsi-meet.
-            if (ex.message !== 'Data channels support is disabled!') {
-                throw ex;
-            }
+            handleEndpointChangeError(ex);
         }
     }
 }

--- a/features/base/conference/middleware.js
+++ b/features/base/conference/middleware.js
@@ -68,7 +68,18 @@ function pinParticipant(store, id) {
                 && (!localParticipant || !localParticipant.pinned))) {
         const conference = state['features/base/conference'].jitsiConference;
 
-        conference.pinParticipant(id);
+        try {
+            conference.pinParticipant(id);
+        } catch (ex) {
+            // XXX DataChannels are initialized at some later point when
+            // conference has multiple participants, but this code might
+            // be executed before. So here we're swallowing a particular
+            // error.
+            // TODO this should be fixed in lib-jitsi-meet.
+            if (ex.message !== 'Data channels support is disabled!') {
+                throw ex;
+            }
+        }
     }
 }
 

--- a/features/largeVideo/actions.js
+++ b/features/largeVideo/actions.js
@@ -28,10 +28,21 @@ export function selectEndpoint() {
             const videoTrack = getTrackByMediaTypeAndParticipant(
                 tracks, MEDIA_TYPE.VIDEO, largeVideo.participantId);
 
-            conference.selectParticipant(
-                videoTrack && videoTrack.videoType === VIDEO_TYPE.CAMERA
-                    ? largeVideo.participantId
-                    : null);
+            try {
+                conference.selectParticipant(
+                    videoTrack && videoTrack.videoType === VIDEO_TYPE.CAMERA
+                        ? largeVideo.participantId
+                        : null);
+            } catch (ex) {
+                // XXX DataChannels are initialized at some later point when
+                // conference has multiple participants, but this code might
+                // be executed before. So here we're swallowing a particular
+                // error.
+                // TODO this should be fixed in lib-jitsi-meet.
+                if (ex.message !== 'Data channels support is disabled!') {
+                    throw ex;
+                }
+            }
         }
     };
 }

--- a/features/largeVideo/actions.js
+++ b/features/largeVideo/actions.js
@@ -1,3 +1,4 @@
+import { handleEndpointChangeError } from '../base/conference';
 import {
     MEDIA_TYPE,
     VIDEO_TYPE
@@ -34,14 +35,7 @@ export function selectEndpoint() {
                         ? largeVideo.participantId
                         : null);
             } catch (ex) {
-                // XXX DataChannels are initialized at some later point when
-                // conference has multiple participants, but this code might
-                // be executed before. So here we're swallowing a particular
-                // error.
-                // TODO this should be fixed in lib-jitsi-meet.
-                if (ex.message !== 'Data channels support is disabled!') {
-                    throw ex;
-                }
+                handleEndpointChangeError(ex);
             }
         }
     };


### PR DESCRIPTION
Originally something should be done on lib-jitsi-meet side
