### PR TITLE
Temp fix for error when trying to load analytics in React-Native environment

### DIFF
--- a/features/base/lib-jitsi-meet/actions.js
+++ b/features/base/lib-jitsi-meet/actions.js
@@ -27,7 +27,13 @@ export function disposeLib() {
  * method.
  * @returns {Function}
  */
-export function initLib(config = {}) {
+// FIXME This is temporary solution until we figure out how to deal with
+// analytics (and callstats) scripts async loading in React-Native environment.
+// Also this is done here and not in config.js because currently we don't have
+// access to config from where initLib() is currently called. This will be
+// changed in scope of another PR.
+// eslint-disable-next-line require-jsdoc
+export function initLib(config = { disableThirdPartyRequests: true }) {
     // XXX We wrapping this to be able to "dispatch" the action, because
     // we will need to dispatch some errors to global error handler at some
     // point.


### PR DESCRIPTION
This is temporary solution until we figure out how to deal with analytics (and callstats) scripts async loading in React-Native environment.

Alternatively we can merge https://github.com/jitsi/lib-jitsi-meet/pull/210, though maybe there will be cases when disabling third party requests is better.
